### PR TITLE
Cleaning reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This project has been inspired by my interest in etymology, in  open source coll
 
 The code and the data are distributed under [Creative Commons Attribution-ShareAlike 3.0](https://creativecommons.org/licenses/by-sa/3.0/)
 
+## Viewing the Site
+
+The site's html files are contained in [resources/html](https://github.com/esterpantaleo/etymology/tree/master/resources/html), and the [resources/html/index.html](https://github.com/esterpantaleo/etymology/tree/master/resources/html/index.html) file is the main page. To view the site, navigate to that directory.
+
 ## Language data
 Files contained in [resources/data](https://github.com/esterpantaleo/etymology/tree/master/resources/data) are imported from Wiktionary and updated when a new dump of the English Wiktionary is generated. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The code and the data are distributed under [Creative Commons Attribution-ShareA
 
 ## Viewing the Site
 
-The site's html files are contained in [resources/html](https://github.com/esterpantaleo/etymology/tree/master/resources/html), and the [resources/html/index.html](https://github.com/esterpantaleo/etymology/tree/master/resources/html/index.html) file is the main page. To view the site, navigate to that directory.
+The site's html files are contained in [the repo root](https://github.com/esterpantaleo/etymology/tree/master/). The main page is [index.html](https://github.com/esterpantaleo/etymology/tree/master/index.html). To view the site you just need to navigate to the root of the repo.
 
 ## Language data
 Files contained in [resources/data](https://github.com/esterpantaleo/etymology/tree/master/resources/data) are imported from Wiktionary and updated when a new dump of the English Wiktionary is generated. 

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta HTTP-EQUIV="X-UA-COMPATIBLE" CONTENT="IE=EmulateIE9" charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-<link rel="stylesheet" href="../css/etytree.css">
-<link rel="stylesheet" href="../css/demo.css">
+<link rel="stylesheet" href="./resources/css/etytree.css">
+<link rel="stylesheet" href="./resources/css/demo.css">
 <link rel="stylesheet" href="https://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.css">
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/hopscotch/0.2.7/css/hopscotch.css">
@@ -12,12 +12,12 @@
 <script src="https://d3js.org/d3.v3.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/hopscotch/0.2.7/js/hopscotch.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.4.1/Rx.min.js"></script>
-<script src="../js/dagre-d3.js"></script>
-<script src="../js/liveTour.js"></script>
-<script src="../js/load.js"></script>
-<script src="../js/sparql.js"></script>   
-<script src="../js/dagre.js"></script>
-<script src="../js/etytree.js"></script>  
+<script src="./resources/js/dagre-d3.js"></script>
+<script src="./resources/js/liveTour.js"></script>
+<script src="./resources/js/load.js"></script>
+<script src="./resources/js/sparql.js"></script>   
+<script src="./resources/js/dagre.js"></script>
+<script src="./resources/js/etytree.js"></script>  
 <body> 
 
 <!--<div data-role="page">-->

--- a/index.toolstart.html
+++ b/index.toolstart.html
@@ -25,7 +25,7 @@ a:-webkit-any-link {
 <table style="empty-cells:hide; margin-left:auto; margin-right:auto;">
 <tr>
 <td>
-<a href="./etymology/resources/html/index.html" target="_blank" data-role="button" data-mini="true">Test etytree</a>
+<a href="./index.html" target="_blank" data-role="button" data-mini="true">Test etytree</a>
 </td>
 <td>
 <a href="https://www.youtube.com/watch?v=cbUK09E_FDY" target="_blank" data-role="button" data-mini="true">Video presentation @ www2017</a>
@@ -47,10 +47,10 @@ a:-webkit-any-link {
 </div>
 <div data-role="main" class="ui-content" >
 After six months of work supported by an <a href="https://meta.wikimedia.org/wiki/Grants:IEG/A_graphical_and_interactive_etymology_dictionary_based_on_Wiktionary">IEG grant</a>, a database of more than 6 million etymology entries in 3365 languages has been generated from the English Wiktionary (SPARQL endpoint <a href="http://etytree-virtuoso.wmflabs.org/sparql"  target="_blank">http://etytree-virtuoso.wmflabs.org</a>) and a first version of the visual etymology dictionary has been released:
-<h1 style="text-align: center;"><a href="./etymology/resources/html/index.html"  target="_blank">etytree</a>
+<h1 style="text-align: center;"><a href="./index.html"  target="_blank">etytree</a>
 <span style="font-size:16px"><br>A graphical and interactive etymology dictionary based on Wiktionary</span></h1>
 
-<img src="./etymology/resources/images/door.png" alt="some_text" style="width:70%;height:70%;float: right;">
+<img src="./resources/images/door.png" alt="some_text" style="width:70%;height:70%;float: right;">
 We are happy to announce that the Wikimedia Foundation has supported us with a second grant! Thanks to all supporters!
 
 There are three main aspects we are tryng to improve right now:

--- a/resources/js/dagre-d3.js
+++ b/resources/js/dagre-d3.js
@@ -4183,7 +4183,7 @@ function dijkstraAll(g, weightFunc, edgeFunc) {
 
 },{"../lodash":77,"./dijkstra":63}],63:[function(require,module,exports){
 var _ = require("../lodash"),
-    PriorityQueue = require("../data/priority-queue");
+    PriorityQueue = require("./resources/data/priority-queue");
 
 module.exports = dijkstra;
 
@@ -4237,7 +4237,7 @@ function runDijkstra(g, source, weightFn, edgeFn) {
   return results;
 }
 
-},{"../data/priority-queue":73,"../lodash":77}],64:[function(require,module,exports){
+},{"./resources/data/priority-queue":73,"../lodash":77}],64:[function(require,module,exports){
 var _ = require("../lodash"),
     tarjan = require("./tarjan");
 
@@ -4354,7 +4354,7 @@ function preorder(g, vs) {
 },{"./dfs":61}],70:[function(require,module,exports){
 var _ = require("../lodash"),
     Graph = require("../graph"),
-    PriorityQueue = require("../data/priority-queue");
+    PriorityQueue = require("./resources/data/priority-queue");
 
 module.exports = prim;
 
@@ -4405,7 +4405,7 @@ function prim(g, weightFunc) {
   return result;
 }
 
-},{"../data/priority-queue":73,"../graph":74,"../lodash":77}],71:[function(require,module,exports){
+},{"./resources/data/priority-queue":73,"../graph":74,"../lodash":77}],71:[function(require,module,exports){
 var _ = require("../lodash");
 
 module.exports = tarjan;

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -182,17 +182,17 @@ var mergeEquivalentNodes = true;
 if (debug) console.log("loading languages");
 var langMap = new Map();
 var ssv = d3.dsv(";", "text/plain");
-ssv("../data/etymology-only_languages.csv", function(data) {
+ssv("./resources/data/etymology-only_languages.csv", function(data) {
     data.forEach(function(entry){
         langMap.set(entry["code"], entry["canonical name"]);
     })
 });
-ssv("../data/list_of_languages.csv", function(data) {
+ssv("./resources/data/list_of_languages.csv", function(data) {
     data.forEach(function(entry){
         langMap.set(entry["code"], entry["canonical name"]);
     })
 });
-d3.text("../data/iso-639-3.tab", function(error, textString){
+d3.text("./resources/data/iso-639-3.tab", function(error, textString){
     var headers = ["Id", "Part2B", "Part2T", "Part1", "Scope", "Language_Type", "Ref_Name", "Comment"].join("\t");
     var data = d3.tsv.parse(headers + textString);
     data.forEach(function(entry){


### PR DESCRIPTION
This puts the html files in the repo root so that the project can easily be run from the root.

The references to files in js files, `index.html`, and `index.toolstart.html` have all been changed based on their new location.

That being said, I am not sure about the context in which you use `index.toolstart.html`, so links in that file to `index.html` may need to be adjusted again.