### PR TITLE
Wrap visual module

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,18 @@
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery-mobile/1.4.5/jquery.mobile.min.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/hopscotch/0.2.7/css/hopscotch.css">
-<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.10.2/jquery.js
-"></script>
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.10.2/jquery.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery-mobile/1.4.5/jquery.mobile.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 <script src="https://d3js.org/d3.v3.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/hopscotch/0.2.7/js/hopscotch.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.4.1/Rx.min.js"></script>
 <script src="./vendors/dagre-d3/dagre-d3.js"></script>
-<script src="./resources/js/liveTour.js"></script>
-<script src="./resources/js/sparql.js"></script>   
-<script src="./resources/js/load.js"></script>
-<script src="./resources/js/dagre.js"></script>
-<script src="./resources/js/etytree.js"></script>  
+<script async src="./resources/js/liveTour.js"></script>
+<script async src="./resources/js/sparql.js"></script>   
+<script async src="./resources/js/load.js"></script>
+<script async src="./resources/js/dagre.js"></script>
+<script async src="./resources/js/etytree.js"></script>  
 <body> 
 
 <!--<div data-role="page">-->

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -100,7 +100,7 @@ var GRAPH = (function(module) {
                         }
                     });
             });
-            if (etyBase.LOAD.settings.debug) {
+            if (etyBase.config.debug) {
                 console.log(g.nodess);
             }
 
@@ -122,7 +122,7 @@ var GRAPH = (function(module) {
             //if parameter == 2 submit a longer (but more detailed) query
             var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.ancestorQuery(iri, parameter));
             var source;
-            if (etyBase.LOAD.settings.debug) {
+            if (etyBase.config.debug) {
                 console.log(url);
             }
             d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.loadingMore);
@@ -472,13 +472,13 @@ var GRAPH = (function(module) {
                     var lemma = $(tag).val(); //.replace("/", "!slash!");
 
                     if (lemma) {
-                        if (etyBase.LOAD.settings.debug) {
+                        if (etyBase.config.debug) {
                             console.log("searching lemma in database");
                         }
                         var width = window.innerWidth,
                             height = $(document).height() - $('#header').height();
                         var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
-                        if (etyBase.LOAD.settings.debug) {
+                        if (etyBase.config.debug) {
                             console.log(url);
                         }
 

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -4,443 +4,457 @@
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
 var GRAPH = (function(module) {
 
-    module.appendLanguageTagTextAndTooltip = function(inner, g) {
-        //append language tag to nodes        
-        inner.selectAll("g.node")
-            .append("text")
-            .style("width", "auto")
-            .style("height", "auto")
-            .style("display", "inline")
-            .attr("class", "isoText")
-            .attr("y", "3em")
-            .attr("x", "1em")
-            .html(function(d) {
-                return g.node(d).iso;
-            });
-        //show tooltip on click on laguage tag
-        inner.selectAll("g.node")
-            .append("rect")
-            .attr("y", "2.2em")
-            .attr("x", "0.8em")
-            .attr("width", function(d) {
-                return g.node(d).iso.length / 1.7 + "em";
-            })
-            .attr("height", "1em")
-            .attr("fill", "red")
-            .attr("fill-opacity", 0)
-            .on("mouseover", function(d) {
-                d3.select("#tooltipPopup")
-                    .style("display", "inline")
-                    .style("left", (d3.event.pageX) + "px")
-                    .style("top", (d3.event.pageY - 28) + "px")
-                    .html(g.node(d).lang);
-                console.log(g.node(d).lang);
-                d3.event.stopPropagation();
-            });
-    };
+    module.bindModule = function(base, moduleName) {
+        var etyBase = base;
 
-    module.appendDefinitionTooltip = function(inner, g) {
-        //show tooltip on click on nodes                  
-        inner.selectAll("g.node")
-            .on("mouseover", function(d) {
-                d3.select("#tooltipPopup")
-                    .style("display", "inline")
-                    .style("left", (d3.event.pageX + 38) + "px")
-                    .style("top", (d3.event.pageY - 28) + "px")
-                    .html("");
-                g.node(d).iri.forEach(
-                    function(iri) {
-                        g.nodess[iri].logTooltip();
-                    });
-                d3.event.stopPropagation();
-            });
-    };
-
-    module.appendDefinitionTooltipOrDrawDAGRE = function(inner, g, width, height) {
-        inner.selectAll("g.node")
-            .on('click', function(d) {
-                var iri = g.node(d).iri;
-                module.drawDAGRE(iri, 2, width, height);
-                d3.select("#tooltipPopup")
-                    .style("display", "none");
-            })
-            .on('mouseover', function(d) {
-
-                d3.select(this).style("cursor", "pointer");
-
-                d3.select("#tooltipPopup")
-                    .style("display", "inline")
-                    .style("left", (d3.event.pageX + 38) + "px")
-                    .style("top", (d3.event.pageY - 28) + "px")
-                    .html("");
-                var iri = g.node(d).iri;
-                g.nodess[iri].logTooltip();
-            });
-    };
-
-    module.buildDisambiguationDAGRE = function(response) {
-        var disambiguationArray = JSON.parse(response).results.bindings;
-        if (disambiguationArray.length === 0) {
-            return null;
-        }
-        var g = new dagreD3.graphlib.Graph().setGraph({});
-
-        //define nodes 
-        g.nodess = {};
-        disambiguationArray.forEach(function(n) {
-            n.et.value.split(",")
-                .forEach(function(element) {
-                    if (element !== "") {
-                        g.nodess[element] = new Node(element);
-                    } else {
-                        g.nodess[n.iri.value] = new Node(n.iri.value);
-                    }
+        var appendLanguageTagTextAndTooltip = function(inner, g) {
+            //append language tag to nodes        
+            inner.selectAll("g.node")
+                .append("text")
+                .style("width", "auto")
+                .style("height", "auto")
+                .style("display", "inline")
+                .attr("class", "isoText")
+                .attr("y", "3em")
+                .attr("x", "1em")
+                .html(function(d) {
+                    return g.node(d).iso;
                 });
-        });
-        if (LOAD.settings.debug) {
-            console.log(g.nodess);
-        }
+            //show tooltip on click on laguage tag
+            inner.selectAll("g.node")
+                .append("rect")
+                .attr("y", "2.2em")
+                .attr("x", "0.8em")
+                .attr("width", function(d) {
+                    return g.node(d).iso.length / 1.7 + "em";
+                })
+                .attr("height", "1em")
+                .attr("fill", "red")
+                .attr("fill-opacity", 0)
+                .on("mouseover", function(d) {
+                    d3.select("#tooltipPopup")
+                        .style("display", "inline")
+                        .style("left", (d3.event.pageX) + "px")
+                        .style("top", (d3.event.pageY - 28) + "px")
+                        .html(g.node(d).lang);
+                    console.log(g.node(d).lang);
+                    d3.event.stopPropagation();
+                });
+        };
 
-        //add nodes and links to the graph
-        var m = null;
-        for (var n in g.nodess) {
-            g.setNode(n, g.nodess[n], { labelStyle: "font-size: 3em" });
-            if (null !== m) {
-                g.setEdge(n, m, { label: "", style: "stroke-width: 0" });
+        var appendDefinitionTooltip = function(inner, g) {
+            //show tooltip on click on nodes                  
+            inner.selectAll("g.node")
+                .on("mouseover", function(d) {
+                    d3.select("#tooltipPopup")
+                        .style("display", "inline")
+                        .style("left", (d3.event.pageX + 38) + "px")
+                        .style("top", (d3.event.pageY - 28) + "px")
+                        .html("");
+                    g.node(d).iri.forEach(
+                        function(iri) {
+                            g.nodess[iri].logTooltip();
+                        });
+                    d3.event.stopPropagation();
+                });
+        };
+
+        var appendDefinitionTooltipOrDrawDAGRE = function(inner, g, width, height) {
+            inner.selectAll("g.node")
+                .on('click', function(d) {
+                    var iri = g.node(d).iri;
+                    etyBase.GRAPH.drawDAGRE(iri, 2, width, height);
+                    d3.select("#tooltipPopup")
+                        .style("display", "none");
+                })
+                .on('mouseover', function(d) {
+
+                    d3.select(this).style("cursor", "pointer");
+
+                    d3.select("#tooltipPopup")
+                        .style("display", "inline")
+                        .style("left", (d3.event.pageX + 38) + "px")
+                        .style("top", (d3.event.pageY - 28) + "px")
+                        .html("");
+                    var iri = g.node(d).iri;
+                    g.nodess[iri].logTooltip();
+                });
+        };
+
+        var buildDisambiguationDAGRE = function(response) {
+            var disambiguationArray = JSON.parse(response).results.bindings;
+            if (disambiguationArray.length === 0) {
+                return null;
             }
-            m = n;
-        }
+            var g = new dagreD3.graphlib.Graph().setGraph({});
 
-        return g;
-    };
-
-    module.drawDAGRE = function(iri, parameter, width, height) {
-        //if parameter == 1 submit a short (but less detailed) query
-        //if parameter == 2 submit a longer (but more detailed) query
-        var url = DB.ENDPOINT + "?query=" + encodeURIComponent(DB.ancestorQuery(iri, parameter));
-        var source;
-        if (LOAD.settings.debug) {
-            console.log(url);
-        }
-        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.loadingMore);
-        d3.select("#tooltipPopup").attr("display", "none");
-        d3.select("#tree-overlay").remove();
-
-        source = DB.getXMLHttpRequest(url);
-
-        source.subscribe(
-            function(response) {
-
-                if (null === response) {
-                    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-                    return;
-                }
-
-                d3.select("#helpPopup").html(LOAD.HELP.dagre);
-
-                var ancestorArray = JSON.parse(response).results.bindings
-                    .reduce((ancestors, a) => {
-                        ancestors.push(a.ancestor1.value);
-                        if (undefined !== a.ancestor2) {
-                            ancestors.push(a.ancestor2.value);
+            //define nodes 
+            g.nodess = {};
+            disambiguationArray.forEach(function(n) {
+                n.et.value.split(",")
+                    .forEach(function(element) {
+                        if (element !== "") {
+                            g.nodess[element] = new Node(element);
+                        } else {
+                            g.nodess[n.iri.value] = new Node(n.iri.value);
                         }
-                        return ancestors;
-                    }, []).filter(onlyUnique);
-
-                console.log("ANCESTORS");
-                console.log(ancestorArray);
-                const subscribe = DB.slicedQuery(ancestorArray, DB.descendantQuery, 8)
-                    .subscribe(
-                        function(val) {
-                            var descendantArray = val.reduce((descendants, d) => {
-                                return descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
-                            }, []);
-                            const subscribe = DB.slicedQuery(descendantArray, DB.propertyQuery, 8)
-                                .subscribe(function(val) {
-                                    var allArray = val.reduce((all, a) => {
-                                        return all.concat(JSON.parse(a).results.bindings);
-                                    }, []);
-                                    if (allArray.length === 0) {
-                                        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.noEtymology);
-                                    } else {
-                                        var g = module.defineGraph(ancestorArray, allArray);
-                                        d3.select("#message").style("display", "none");
-
-                                        var inner = module.renderGraph(g, width, height);
-                                        module.appendLanguageTagTextAndTooltip(inner, g);
-                                        module.appendDefinitionTooltip(inner, g);
-                                    }
-                                });
-                        },
-                        function(error) {
-                            d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-                            console.log(error);
-                        },
-                        () => console.log('done descendants query'));
-            },
-            function(error) {
-                if (parameter === 1) {
-                    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-                    console.log(error);
-                } else {
-                    module.drawDAGRE(iri, 1, width, height);
-                }
-            },
-            function() {
-                console.log('done DAGRE' + parameter);
+                    });
             });
-    };
+            if (etyBase.LOAD.settings.debug) {
+                console.log(g.nodess);
+            }
 
-    module.defineGraph = function(ancestors, response) {
-        var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+            //add nodes and links to the graph
+            var m = null;
+            for (var n in g.nodess) {
+                g.setNode(n, g.nodess[n], { labelStyle: "font-size: 3em" });
+                if (null !== m) {
+                    g.setEdge(n, m, { label: "", style: "stroke-width: 0" });
+                }
+                m = n;
+            }
 
-        //CONSTRUCTING NODES
-        g.nodess = {};
-        response.forEach(function(element) {
-            //save all nodes        
-            //define isAncestor
-            if (undefined !== element.s && (undefined === g.nodess[element.s.value] || null === g.nodess[element.s.value])) {
-                g.nodess[element.s.value] = new Node(element.s.value);
-                if (ancestors.indexOf(element.s.value) > -1) {
-                    g.nodess[element.s.value].isAncestor = true;
-                }
-            }
-            if (undefined !== element.rel && (undefined === g.nodess[element.rel.value] || null === g.nodess[element.rel.value])) {
-                g.nodess[element.rel.value] = new Node(element.rel.value);
-                if (ancestors.indexOf(element.rel.value) > -1) {
-                    g.nodess[element.s.value].isAncestor = true;
-                }
-            }
-            if (undefined !== element.rel && undefined !== element.eq) {
-                if (undefined === g.nodess[element.eq.value] || null === g.nodess[element.eq.value]) {
-                    g.nodess[element.eq.value] = new Node(element.eq.value);
-                }
-                if (ancestors.indexOf(element.eq.value) > -1) {
-                    g.nodess[element.eq.value].isAncestor = true;
-                }
-                //push to eqIri
-                g.nodess[element.rel.value].eqIri.push(element.eq.value);
-                g.nodess[element.eq.value].eqIri.push(element.rel.value);
-            }
-            if (undefined !== element.der) {
-                if (undefined === g.nodess[element.der.value] || null === g.nodess[element.der.value]) {
-                    g.nodess[element.der.value] = new Node(element.der.value);
-                }
-                //add property der
-                g.nodess[element.s.value].der = true;
-            }
-        });
+            return g;
+        };
 
-        //CONSTRUCTING GRAPHNODES
-        //a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
-        //or that refer to the same word - also called here identical Nodes 
-        //(e.g.: if only ee_word and ee_n_word with n an integer belong to                                                                          
-        //the set of ancestors and descendants                                                                                                
-        //then merge them into one graphNode) 
-        //the final graph will use these super nodes (graphNodes)  
-        g.graphNodes = {};
-        var counter = 0; //counts how many graphNodes have been created so far
-        for (var n in g.nodess) {
-            if (g.nodess[n].ety === 0) {
-                var tmp = [];
-                var iso = g.nodess[n].iso;
-                var label = g.nodess[n].label;
-                for (var m in g.nodess) {
-                    if (undefined !== g.nodess[m]) {
-                        if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
-                            if (g.nodess[m].ety > 0) {
-                                tmp.push(m);
+        var drawDAGRE = function(iri, parameter, width, height) {
+            //if parameter == 1 submit a short (but less detailed) query
+            //if parameter == 2 submit a longer (but more detailed) query
+            var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.ancestorQuery(iri, parameter));
+            var source;
+            if (etyBase.LOAD.settings.debug) {
+                console.log(url);
+            }
+            d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.loadingMore);
+            d3.select("#tooltipPopup").attr("display", "none");
+            d3.select("#tree-overlay").remove();
+
+            source = etyBase.DB.getXMLHttpRequest(url);
+
+            source.subscribe(
+                function(response) {
+
+                    if (null === response) {
+                        d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.serverError);
+                        return;
+                    }
+
+                    d3.select("#helpPopup").html(etyBase.LOAD.HELP.dagre);
+
+                    var ancestorArray = JSON.parse(response).results.bindings
+                        .reduce((ancestors, a) => {
+                            ancestors.push(a.ancestor1.value);
+                            if (undefined !== a.ancestor2) {
+                                ancestors.push(a.ancestor2.value);
+                            }
+                            return ancestors;
+                        }, []).filter(onlyUnique);
+
+                    console.log("ANCESTORS");
+                    console.log(ancestorArray);
+                    const subscribe = etyBase.DB.slicedQuery(ancestorArray, etyBase.DB.descendantQuery, 8)
+                        .subscribe(
+                            function(val) {
+                                var descendantArray = val.reduce((descendants, d) => {
+                                    return descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
+                                }, []);
+                                const subscribe = etyBase.DB.slicedQuery(descendantArray, etyBase.DB.propertyQuery, 8)
+                                    .subscribe(function(val) {
+                                        var allArray = val.reduce((all, a) => {
+                                            return all.concat(JSON.parse(a).results.bindings);
+                                        }, []);
+                                        if (allArray.length === 0) {
+                                            d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.noEtymology);
+                                        } else {
+                                            var g = etyBase.GRAPH.defineGraph(ancestorArray, allArray);
+                                            d3.select("#message").style("display", "none");
+
+                                            var inner = etyBase.GRAPH.renderGraph(g, width, height);
+                                            etyBase.GRAPH.appendLanguageTagTextAndTooltip(inner, g);
+                                            etyBase.GRAPH.appendDefinitionTooltip(inner, g);
+                                        }
+                                    });
+                            },
+                            function(error) {
+                                d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.serverError);
+                                console.log(error);
+                            },
+                            () => console.log('done descendants query'));
+                },
+                function(error) {
+                    if (parameter === 1) {
+                        d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.serverError);
+                        console.log(error);
+                    } else {
+                        etyBase.GRAPH.drawDAGRE(iri, 1, width, height);
+                    }
+                },
+                function() {
+                    console.log('done DAGRE' + parameter);
+                });
+        };
+
+        var defineGraph = function(ancestors, response) {
+            var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+
+            //CONSTRUCTING NODES
+            g.nodess = {};
+            response.forEach(function(element) {
+                //save all nodes        
+                //define isAncestor
+                if (undefined !== element.s && (undefined === g.nodess[element.s.value] || null === g.nodess[element.s.value])) {
+                    g.nodess[element.s.value] = new Node(element.s.value);
+                    if (ancestors.indexOf(element.s.value) > -1) {
+                        g.nodess[element.s.value].isAncestor = true;
+                    }
+                }
+                if (undefined !== element.rel && (undefined === g.nodess[element.rel.value] || null === g.nodess[element.rel.value])) {
+                    g.nodess[element.rel.value] = new Node(element.rel.value);
+                    if (ancestors.indexOf(element.rel.value) > -1) {
+                        g.nodess[element.s.value].isAncestor = true;
+                    }
+                }
+                if (undefined !== element.rel && undefined !== element.eq) {
+                    if (undefined === g.nodess[element.eq.value] || null === g.nodess[element.eq.value]) {
+                        g.nodess[element.eq.value] = new Node(element.eq.value);
+                    }
+                    if (ancestors.indexOf(element.eq.value) > -1) {
+                        g.nodess[element.eq.value].isAncestor = true;
+                    }
+                    //push to eqIri
+                    g.nodess[element.rel.value].eqIri.push(element.eq.value);
+                    g.nodess[element.eq.value].eqIri.push(element.rel.value);
+                }
+                if (undefined !== element.der) {
+                    if (undefined === g.nodess[element.der.value] || null === g.nodess[element.der.value]) {
+                        g.nodess[element.der.value] = new Node(element.der.value);
+                    }
+                    //add property der
+                    g.nodess[element.s.value].der = true;
+                }
+            });
+
+            //CONSTRUCTING GRAPHNODES
+            //a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
+            //or that refer to the same word - also called here identical Nodes 
+            //(e.g.: if only ee_word and ee_n_word with n an integer belong to                                                                          
+            //the set of ancestors and descendants                                                                                                
+            //then merge them into one graphNode) 
+            //the final graph will use these super nodes (graphNodes)  
+            g.graphNodes = {};
+            var counter = 0; //counts how many graphNodes have been created so far
+            for (var n in g.nodess) {
+                if (g.nodess[n].ety === 0) {
+                    var tmp = [];
+                    var iso = g.nodess[n].iso;
+                    var label = g.nodess[n].label;
+                    for (var m in g.nodess) {
+                        if (undefined !== g.nodess[m]) {
+                            if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
+                                if (g.nodess[m].ety > 0) {
+                                    tmp.push(m);
+                                }
+                            }
+                        }
+                    }
+                    tmp = tmp.filter(onlyUnique);
+                    //if only ee_word and ee_n_word with n an integer belong to
+                    //the set of ancestors and descendants
+                    //then merge them in one graphNode
+                    if (tmp.length === 1) {
+                        var gg = new GraphNode(counter);
+                        //initialize graphNode.all 
+                        gg.all.push(n);
+                        //define graphNode.iri 
+                        gg.iri = g.nodess[tmp[0]].eqIri;
+                        gg.iri.push(tmp[0]);
+                        //define node.graphNode
+                        g.nodess[n].graphNode.push(counter);
+                        g.nodess[tmp[0]].graphNode.push(counter);
+                        gg.iri.forEach(function(element) {
+                            g.nodess[element].graphNode.push(counter);
+                        });
+
+                        //push to graphNodes
+                        g.graphNodes[counter] = gg;
+                        g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(onlyUnique);
+                        counter++;
+                    }
+                }
+            }
+
+            for (var n in g.nodess) {
+                if (g.nodess[n].graphNode.length === 0) {
+                    //add iri
+                    var gg = new GraphNode(counter);
+                    gg.iri = g.nodess[n].eqIri;
+                    gg.iri.push(n);
+                    var tmp = [];
+                    gg.iri.forEach(function(element) {
+                        tmp.concat(element.eqIri);
+                    });
+                    gg.iri.concat(tmp);
+                    gg.iri = gg.iri.filter(onlyUnique);
+                    gg.iri.forEach(function(element) {
+                        g.nodess[element].graphNode.push(counter);
+                    });
+                    g.graphNodes[counter] = gg;
+                    counter++;
+                } else {
+                    var graphNode = g.nodess[n].graphNode[0];
+
+                    g.nodess[n].eqIri.forEach(function(element) {
+                        //add iri
+                        g.nodess[element].graphNode.push(graphNode);
+                        g.graphNodes[graphNode].iri.concat(g.nodess[element].eqIri);
+                        g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(onlyUnique);
+                    });
+                }
+            }
+
+            var showDerivedNodes = true;
+            if (ancestors.length < 3) showDerivedNodes = true;
+
+            for (var gg in g.graphNodes) {
+                //define all
+                g.graphNodes[gg].all = g.graphNodes[gg].all.concat(g.graphNodes[gg].iri);
+
+                //define isAncestor
+                if (g.graphNodes[gg].all.filter(function(element) { return g.nodess[element].isAncestor; }).length > 0) {
+                    g.graphNodes[gg].isAncestor = true;
+                }
+
+                //define der
+                var der = g.graphNodes[gg].all.filter(function(element) {
+                    return g.nodess[element].der !== undefined;
+                });
+                if (der.length > 0) {
+                    g.graphNodes[gg].der = true;
+                }
+
+                //define iso, label, lang
+                g.graphNodes[gg].iso = g.nodess[g.graphNodes[gg].all[0]].iso;
+                g.graphNodes[gg].label = g.graphNodes[gg].iri.map(function(i) { return g.nodess[i].label; }).join(",");
+                g.graphNodes[gg].lang = g.nodess[g.graphNodes[gg].all[0]].lang;
+            }
+
+            //define linkedToTarget and linkedToSource
+            response.forEach(function(element) {
+                if (element.rel !== undefined && element.s !== undefined) {
+                    var source = g.nodess[element.rel.value].graphNode[0],
+                        target = g.nodess[element.s.value].graphNode[0];
+
+                    if (source !== target) {
+                        if (showDerivedNodes) {
+                            g.graphNodes[source].linkedToTarget.push(target);
+                        } else {
+                            //linkedToTarget only counts the number of descendants that are not derived words
+                            if (!(g.graphNodes[source].der || g.graphNodes[target].der)) {
+                                g.graphNodes[source].linkedToTarget.push(target);
+                            }
+                        }
+                        if (g.graphNodes[target].linkedToSource.indexOf(source) === -1) {
+                            g.graphNodes[target].linkedToSource.push(source);
+                        }
+                    }
+                }
+            });
+
+            for (var gg in g.graphNodes) {
+                //collapse nodes that have more than 10 descendants and color them differently      
+                if (!showDerivedNodes && g.graphNodes[gg].linkedToTarget.length > 10) {
+                    console.log("the following node has more than 10 targets: collapsing");
+                    console.log(g.graphNodes[gg]);
+                    g.graphNodes[gg].linkedToTarget.map(function(e) {
+                        if (g.graphNodes[e].linkedToSource.length === 1) {
+                            g.graphNodes[e].der = true;
+                        }
+                    });
+
+                    //    graphNodes[gg].linkedToTarget.map(function(e){  graphNodes[e].der = true; });
+                    g.graphNodes[gg].style = "fill: sandyBrown; stroke: lightBlue";
+                }
+            }
+
+            //CONSTRUCTING LINKS
+            var links = [];
+            response.forEach(function(element) {
+                if (undefined !== element.rel && undefined !== element.s) {
+                    var source = g.nodess[element.rel.value].graphNode[0],
+                        target = g.nodess[element.s.value].graphNode[0];
+                    if (source !== target) {
+                        if (showDerivedNodes || g.graphNodes[target].isAncestor || !(g.graphNodes[source].der || g.graphNodes[target].der)) {
+                            var Link = { "source": source, "target": target };
+                            if (g.graphNodes[target].linkedToSourceCopy.indexOf(source) === -1) {
+                                //define linked and linkedToSourceCopy
+                                links.push(Link);
+                                g.graphNodes[source].linked = true;
+                                g.graphNodes[target].linkedToSourceCopy.push(source);
+                                g.graphNodes[target].linked = true;
                             }
                         }
                     }
                 }
-                tmp = tmp.filter(onlyUnique);
-                //if only ee_word and ee_n_word with n an integer belong to
-                //the set of ancestors and descendants
-                //then merge them in one graphNode
-                if (tmp.length === 1) {
-                    var gg = new GraphNode(counter);
-                    //initialize graphNode.all 
-                    gg.all.push(n);
-                    //define graphNode.iri 
-                    gg.iri = g.nodess[tmp[0]].eqIri;
-                    gg.iri.push(tmp[0]);
-                    //define node.graphNode
-                    g.nodess[n].graphNode.push(counter);
-                    g.nodess[tmp[0]].graphNode.push(counter);
-                    gg.iri.forEach(function(element) {
-                        g.nodess[element].graphNode.push(counter);
-                    });
-
-                    //push to graphNodes
-                    g.graphNodes[counter] = gg;
-                    g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(onlyUnique);
-                    counter++;
-                }
-            }
-        }
-
-        for (var n in g.nodess) {
-            if (g.nodess[n].graphNode.length === 0) {
-                //add iri
-                var gg = new GraphNode(counter);
-                gg.iri = g.nodess[n].eqIri;
-                gg.iri.push(n);
-                var tmp = [];
-                gg.iri.forEach(function(element) {
-                    tmp.concat(element.eqIri);
-                });
-                gg.iri.concat(tmp);
-                gg.iri = gg.iri.filter(onlyUnique);
-                gg.iri.forEach(function(element) {
-                    g.nodess[element].graphNode.push(counter);
-                });
-                g.graphNodes[counter] = gg;
-                counter++;
-            } else {
-                var graphNode = g.nodess[n].graphNode[0];
-
-                g.nodess[n].eqIri.forEach(function(element) {
-                    //add iri
-                    g.nodess[element].graphNode.push(graphNode);
-                    g.graphNodes[graphNode].iri.concat(g.nodess[element].eqIri);
-                    g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(onlyUnique);
-                });
-            }
-        }
-
-        var showDerivedNodes = true;
-        if (ancestors.length < 3) showDerivedNodes = true;
-
-        for (var gg in g.graphNodes) {
-            //define all
-            g.graphNodes[gg].all = g.graphNodes[gg].all.concat(g.graphNodes[gg].iri);
-
-            //define isAncestor
-            if (g.graphNodes[gg].all.filter(function(element) { return g.nodess[element].isAncestor; }).length > 0) {
-                g.graphNodes[gg].isAncestor = true;
-            }
-
-            //define der
-            var der = g.graphNodes[gg].all.filter(function(element) {
-                return g.nodess[element].der !== undefined;
             });
-            if (der.length > 0) {
-                g.graphNodes[gg].der = true;
-            }
 
-            //define iso, label, lang
-            g.graphNodes[gg].iso = g.nodess[g.graphNodes[gg].all[0]].iso;
-            g.graphNodes[gg].label = g.graphNodes[gg].iri.map(function(i) { return g.nodess[i].label; }).join(",");
-            g.graphNodes[gg].lang = g.nodess[g.graphNodes[gg].all[0]].lang;
-        }
-
-        //define linkedToTarget and linkedToSource
-        response.forEach(function(element) {
-            if (element.rel !== undefined && element.s !== undefined) {
-                var source = g.nodess[element.rel.value].graphNode[0],
-                    target = g.nodess[element.s.value].graphNode[0];
-
-                if (source !== target) {
-                    if (showDerivedNodes) {
-                        g.graphNodes[source].linkedToTarget.push(target);
-                    } else {
-                        //linkedToTarget only counts the number of descendants that are not derived words
-                        if (!(g.graphNodes[source].der || g.graphNodes[target].der)) {
-                            g.graphNodes[source].linkedToTarget.push(target);
-                        }
-                    }
-                    if (g.graphNodes[target].linkedToSource.indexOf(source) === -1) {
-                        g.graphNodes[target].linkedToSource.push(source);
-                    }
+            //INITIALIZING NODES IN GRAPH
+            //only draw nodes that are linked to other nodes
+            //always show ancestors
+            for (var gg in g.graphNodes) {
+                if (g.graphNodes[gg].linked || g.graphNodes[gg].isAncestor) {
+                    g.setNode(gg, g.graphNodes[gg]);
                 }
             }
-        });
 
-        for (var gg in g.graphNodes) {
-            //collapse nodes that have more than 10 descendants and color them differently      
-            if (!showDerivedNodes && g.graphNodes[gg].linkedToTarget.length > 10) {
-                console.log("the following node has more than 10 targets: collapsing");
-                console.log(g.graphNodes[gg]);
-                g.graphNodes[gg].linkedToTarget.map(function(e) {
-                    if (g.graphNodes[e].linkedToSource.length === 1) {
-                        g.graphNodes[e].der = true;
-                    }
-                });
+            //INITIALIZING LINKS IN GRAPH
+            links.forEach(function(element) {
+                g.setEdge(element.source,
+                    element.target, { label: "", lineInterpolate: "basis" });
+            });
 
-                //    graphNodes[gg].linkedToTarget.map(function(e){  graphNodes[e].der = true; });
-                g.graphNodes[gg].style = "fill: sandyBrown; stroke: lightBlue";
-            }
-        }
+            return g;
+        };
 
-        //CONSTRUCTING LINKS
-        var links = [];
-        response.forEach(function(element) {
-            if (undefined !== element.rel && undefined !== element.s) {
-                var source = g.nodess[element.rel.value].graphNode[0],
-                    target = g.nodess[element.s.value].graphNode[0];
-                if (source !== target) {
-                    if (showDerivedNodes || g.graphNodes[target].isAncestor || !(g.graphNodes[source].der || g.graphNodes[target].der)) {
-                        var Link = { "source": source, "target": target };
-                        if (g.graphNodes[target].linkedToSourceCopy.indexOf(source) === -1) {
-                            //define linked and linkedToSourceCopy
-                            links.push(Link);
-                            g.graphNodes[source].linked = true;
-                            g.graphNodes[target].linkedToSourceCopy.push(source);
-                            g.graphNodes[target].linked = true;
-                        }
-                    }
-                }
-            }
-        });
+        var renderGraph = function(g, width, height) {
+            var svg = d3.select("#tree-container").append("svg")
+                .attr("id", "tree-overlay")
+                .attr("width", width)
+                .attr("height", height);
 
-        //INITIALIZING NODES IN GRAPH
-        //only draw nodes that are linked to other nodes
-        //always show ancestors
-        for (var gg in g.graphNodes) {
-            if (g.graphNodes[gg].linked || g.graphNodes[gg].isAncestor) {
-                g.setNode(gg, g.graphNodes[gg]);
-            }
-        }
+            var inner = svg.append("g");
 
-        //INITIALIZING LINKS IN GRAPH
-        links.forEach(function(element) {
-            g.setEdge(element.source,
-                element.target, { label: "", lineInterpolate: "basis" });
-        });
+            // Set up zoom support                      
+            var zoom = d3.behavior.zoom().on("zoom", function() {
+                inner.attr("transform", "translate(" + d3.event.translate + ")" +
+                    "scale(" + d3.event.scale + ")");
+            });
+            svg.call(zoom); //.on("dblclick.zoom", null);
 
-        return g;
-    };
+            // Create the renderer          
+            var render = new dagreD3.render();
 
-    module.renderGraph = function(g, width, height) {
-        var svg = d3.select("#tree-container").append("svg")
-            .attr("id", "tree-overlay")
-            .attr("width", width)
-            .attr("height", height);
+            // Run the renderer. This is what draws the final graph.  
+            render(inner, g);
 
-        var inner = svg.append("g");
+            // Center the graph       
+            var initialScale = 0.75;
+            zoom.translate([(width - g.graph().width * initialScale) / 2, 20])
+                .scale(initialScale)
+                .event(svg);
 
-        // Set up zoom support                      
-        var zoom = d3.behavior.zoom().on("zoom", function() {
-            inner.attr("transform", "translate(" + d3.event.translate + ")" +
-                "scale(" + d3.event.scale + ")");
-        });
-        svg.call(zoom); //.on("dblclick.zoom", null);
+            //svg.attr("height", g.graph().height * initialScale + 40);}}
+            return inner;
+        };
 
-        // Create the renderer          
-        var render = new dagreD3.render();
+        this.appendLanguageTagTextAndTooltip = appendLanguageTagTextAndTooltip;
+        this.appendDefinitionTooltip = appendDefinitionTooltip;
+        this.appendDefinitionTooltipOrDrawDAGRE = appendDefinitionTooltipOrDrawDAGRE;
+        this.buildDisambiguationDAGRE = buildDisambiguationDAGRE;
+        this.drawDAGRE = drawDAGRE;
+        this.defineGraph = defineGraph;
+        this.renderGraph = renderGraph;
 
-        // Run the renderer. This is what draws the final graph.  
-        render(inner, g);
-
-        // Center the graph       
-        var initialScale = 0.75;
-        zoom.translate([(width - g.graph().width * initialScale) / 2, 20])
-            .scale(initialScale)
-            .event(svg);
-
-        //svg.attr("height", g.graph().height * initialScale + 40);}}
-        return inner;
+        etyBase[moduleName] = this;
     };
 
     return module;

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,5 +1,5 @@
 /*globals
-    d3, console, LOAD, dagreD3, GraphNode, SPARQL, Node, Rx, onlyUnique
+    d3, console, LOAD, dagreD3, GraphNode, DB, Node, Rx, onlyUnique
 */
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
 var GRAPH = (function(module) {
@@ -117,7 +117,7 @@ var GRAPH = (function(module) {
     module.drawDAGRE = function(iri, parameter, width, height) {
         //if parameter == 1 submit a short (but less detailed) query
         //if parameter == 2 submit a longer (but more detailed) query
-        var url = SPARQL.ENDPOINT + "?query=" + encodeURIComponent(SPARQL.ancestorQuery(iri, parameter));
+        var url = DB.ENDPOINT + "?query=" + encodeURIComponent(DB.ancestorQuery(iri, parameter));
         var source;
         if (LOAD.settings.debug) {
             console.log(url);
@@ -126,7 +126,7 @@ var GRAPH = (function(module) {
         d3.select("#tooltipPopup").attr("display", "none");
         d3.select("#tree-overlay").remove();
 
-        source = SPARQL.getXMLHttpRequest(url);
+        source = DB.getXMLHttpRequest(url);
 
         source.subscribe(
             function(response) {
@@ -149,13 +149,13 @@ var GRAPH = (function(module) {
 
                 console.log("ANCESTORS");
                 console.log(ancestorArray);
-                const subscribe = SPARQL.slicedQuery(ancestorArray, SPARQL.descendantQuery, 8)
+                const subscribe = DB.slicedQuery(ancestorArray, DB.descendantQuery, 8)
                     .subscribe(
                         function(val) {
                             var descendantArray = val.reduce((descendants, d) => {
                                 return descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
                             }, []);
-                            const subscribe = SPARQL.slicedQuery(descendantArray, SPARQL.propertyQuery, 8)
+                            const subscribe = DB.slicedQuery(descendantArray, DB.propertyQuery, 8)
                                 .subscribe(function(val) {
                                     var allArray = val.reduce((all, a) => {
                                         return all.concat(JSON.parse(a).results.bindings);

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,443 +1,448 @@
 /*globals
-    d3, console, LOAD, dagreD3, GraphNode, sortUnique, SPARQL, Node, Rx, onlyUnique
+    d3, console, LOAD, dagreD3, GraphNode, SPARQL, Node, Rx, onlyUnique
 */
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
+var GRAPH = (function(module) {
 
-function appendLanguageTagTextAndTooltip(inner, g) {
-    //append language tag to nodes        
-    inner.selectAll("g.node")
-        .append("text")
-        .style("width", "auto")
-        .style("height", "auto")
-        .style("display", "inline")
-        .attr("class", "isoText")
-        .attr("y", "3em")
-        .attr("x", "1em")
-        .html(function(d) {
-            return g.node(d).iso;
-        });
-    //show tooltip on click on laguage tag
-    inner.selectAll("g.node")
-        .append("rect")
-        .attr("y", "2.2em")
-        .attr("x", "0.8em")
-        .attr("width", function(d) {
-            return g.node(d).iso.length / 1.7 + "em";
-        })
-        .attr("height", "1em")
-        .attr("fill", "red")
-        .attr("fill-opacity", 0)
-        .on("mouseover", function(d) {
-            d3.select("#tooltipPopup")
-                .style("display", "inline")
-                .style("left", (d3.event.pageX) + "px")
-                .style("top", (d3.event.pageY - 28) + "px")
-                .html(g.node(d).lang);
-            console.log(g.node(d).lang);
-            d3.event.stopPropagation();
-        });
-}
-
-function appendDefinitionTooltip(inner, g) {
-    //show tooltip on click on nodes                  
-    inner.selectAll("g.node")
-        .on("mouseover", function(d) {
-            d3.select("#tooltipPopup")
-                .style("display", "inline")
-                .style("left", (d3.event.pageX + 38) + "px")
-                .style("top", (d3.event.pageY - 28) + "px")
-                .html("");
-            g.node(d).iri.forEach(
-                function(iri) {
-                    g.nodess[iri].logTooltip();
-                });
-            d3.event.stopPropagation();
-        });
-}
-
-function appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height) {
-    inner.selectAll("g.node")
-        .on('click', function(d) {
-            var iri = g.node(d).iri;
-            drawDAGRE(iri, 2, width, height);
-            d3.select("#tooltipPopup")
-                .style("display", "none");
-        })
-        .on('mouseover', function(d) {
-
-	  d3.select(this).style("cursor", "pointer");
-
-	  d3.select("#tooltipPopup")
-		    .style("display", "inline") 
-		    .style("left", (d3.event.pageX + 38) + "px")
-		    .style("top", (d3.event.pageY - 28) + "px")
-		    .html("");
-	  var iri = g.node(d).iri;
-	  g.nodess[iri].logTooltip();
-	});
-}
-
-function buildDisambiguationDAGRE(response) {
-    var disambiguationArray = JSON.parse(response).results.bindings;
-    if (disambiguationArray.length === 0) {
-        return null;
-    }
-    var g = new dagreD3.graphlib.Graph().setGraph({});
-
-    //define nodes 
-    g.nodess = {};
-    disambiguationArray.forEach(function(n) {
-        n.et.value.split(",")
-            .forEach(function(element) {
-                if (element !== "") {
-                    g.nodess[element] = new Node(element);
-                } else {
-                    g.nodess[n.iri.value] = new Node(n.iri.value);
-                }
+    module.appendLanguageTagTextAndTooltip = function(inner, g) {
+        //append language tag to nodes        
+        inner.selectAll("g.node")
+            .append("text")
+            .style("width", "auto")
+            .style("height", "auto")
+            .style("display", "inline")
+            .attr("class", "isoText")
+            .attr("y", "3em")
+            .attr("x", "1em")
+            .html(function(d) {
+                return g.node(d).iso;
             });
-    });
-    if (LOAD.settings.debug) {
-        console.log(g.nodess);
-    }
+        //show tooltip on click on laguage tag
+        inner.selectAll("g.node")
+            .append("rect")
+            .attr("y", "2.2em")
+            .attr("x", "0.8em")
+            .attr("width", function(d) {
+                return g.node(d).iso.length / 1.7 + "em";
+            })
+            .attr("height", "1em")
+            .attr("fill", "red")
+            .attr("fill-opacity", 0)
+            .on("mouseover", function(d) {
+                d3.select("#tooltipPopup")
+                    .style("display", "inline")
+                    .style("left", (d3.event.pageX) + "px")
+                    .style("top", (d3.event.pageY - 28) + "px")
+                    .html(g.node(d).lang);
+                console.log(g.node(d).lang);
+                d3.event.stopPropagation();
+            });
+    };
 
-    //add nodes and links to the graph
-    var m = null;
-    for (var n in g.nodess) {
-        g.setNode(n, g.nodess[n], { labelStyle: "font-size: 3em" });
-        if (null !== m) {
-            g.setEdge(n, m, { label: "", style: "stroke-width: 0" });
+    module.appendDefinitionTooltip = function(inner, g) {
+        //show tooltip on click on nodes                  
+        inner.selectAll("g.node")
+            .on("mouseover", function(d) {
+                d3.select("#tooltipPopup")
+                    .style("display", "inline")
+                    .style("left", (d3.event.pageX + 38) + "px")
+                    .style("top", (d3.event.pageY - 28) + "px")
+                    .html("");
+                g.node(d).iri.forEach(
+                    function(iri) {
+                        g.nodess[iri].logTooltip();
+                    });
+                d3.event.stopPropagation();
+            });
+    };
+
+    module.appendDefinitionTooltipOrDrawDAGRE = function(inner, g, width, height) {
+        inner.selectAll("g.node")
+            .on('click', function(d) {
+                var iri = g.node(d).iri;
+                module.drawDAGRE(iri, 2, width, height);
+                d3.select("#tooltipPopup")
+                    .style("display", "none");
+            })
+            .on('mouseover', function(d) {
+
+                d3.select(this).style("cursor", "pointer");
+
+                d3.select("#tooltipPopup")
+                    .style("display", "inline")
+                    .style("left", (d3.event.pageX + 38) + "px")
+                    .style("top", (d3.event.pageY - 28) + "px")
+                    .html("");
+                var iri = g.node(d).iri;
+                g.nodess[iri].logTooltip();
+            });
+    };
+
+    module.buildDisambiguationDAGRE = function(response) {
+        var disambiguationArray = JSON.parse(response).results.bindings;
+        if (disambiguationArray.length === 0) {
+            return null;
         }
-        m = n;
-    }
+        var g = new dagreD3.graphlib.Graph().setGraph({});
 
-    return g;
-}
-
-function drawDAGRE(iri, parameter, width, height) {
-    //if parameter == 1 submit a short (but less detailed) query
-    //if parameter == 2 submit a longer (but more detailed) query
-    var url = SPARQL.ENDPOINT + "?query=" + encodeURIComponent(SPARQL.ancestorQuery(iri, parameter));
-    var source;
-    if (LOAD.settings.debug) {
-        console.log(url);
-    }
-    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.loadingMore);
-    d3.select("#tooltipPopup").attr("display", "none");
-    d3.select("#tree-overlay").remove();
-
-    source = SPARQL.getXMLHttpRequest(url);
-
-    source.subscribe(
-        function(response) {
-
-            if (null === response) {
-		            d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-                return;
-            }
-
-            d3.select("#helpPopup").html(LOAD.HELP.dagre);
-
-            var ancestorArray = JSON.parse(response).results.bindings
-                .reduce((ancestors, a) => {
-                    ancestors.push(a.ancestor1.value);
-                    if (undefined !== a.ancestor2) {
-                        ancestors.push(a.ancestor2.value);
+        //define nodes 
+        g.nodess = {};
+        disambiguationArray.forEach(function(n) {
+            n.et.value.split(",")
+                .forEach(function(element) {
+                    if (element !== "") {
+                        g.nodess[element] = new Node(element);
+                    } else {
+                        g.nodess[n.iri.value] = new Node(n.iri.value);
                     }
-                    return ancestors;
-                }, []).filter(onlyUnique);
-
-            console.log("ANCESTORS");
-            console.log(ancestorArray);
-            const subscribe = SPARQL.slicedQuery(ancestorArray, SPARQL.descendantQuery, 8)
-                .subscribe(
-                    function(val) {
-                        var descendantArray = val.reduce((descendants, d) => {
-                            return descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
-                        }, []);
-                        const subscribe = SPARQL.slicedQuery(descendantArray, SPARQL.propertyQuery, 8)
-                            .subscribe(function(val) {
-                                var allArray = val.reduce((all, a) => {
-                                    return all.concat(JSON.parse(a).results.bindings);
-                                }, []);
-                                if (allArray.length === 0) {
-                                    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.noEtymology);
-                                } else {
-                                    var g = defineGraph(ancestorArray, allArray);
-				                            d3.select("#message").style("display", "none");
-
-                                    var inner = renderGraph(g, width, height);
-                                    appendLanguageTagTextAndTooltip(inner, g);
-                                    appendDefinitionTooltip(inner, g);
-                                }
-                            });
-                    },
-                    function(error) {
-			                  d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-			                  console.log(error);
-		                },
-                    () => console.log('done descendants query'));
-        },
-        function(error) {
-            if (parameter === 1) {
-		            d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
-		            console.log(error);
-            } else {
-                drawDAGRE(iri, 1, width, height);
-            }
-        },
-        function() {
-            console.log('done DAGRE' + parameter);
+                });
         });
-}
+        if (LOAD.settings.debug) {
+            console.log(g.nodess);
+        }
 
-function defineGraph(ancestors, response) {
-    var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+        //add nodes and links to the graph
+        var m = null;
+        for (var n in g.nodess) {
+            g.setNode(n, g.nodess[n], { labelStyle: "font-size: 3em" });
+            if (null !== m) {
+                g.setEdge(n, m, { label: "", style: "stroke-width: 0" });
+            }
+            m = n;
+        }
 
-    //CONSTRUCTING NODES
-    g.nodess = {};
-    response.forEach(function(element) {
-        //save all nodes        
-        //define isAncestor
-        if (undefined !== element.s && (undefined === g.nodess[element.s.value] || null === g.nodess[element.s.value])) {
-            g.nodess[element.s.value] = new Node(element.s.value);
-            if (ancestors.indexOf(element.s.value) > -1) {
-                g.nodess[element.s.value].isAncestor = true;
-            }
-        }
-        if (undefined !== element.rel && (undefined === g.nodess[element.rel.value] || null === g.nodess[element.rel.value])) {
-            g.nodess[element.rel.value] = new Node(element.rel.value);
-            if (ancestors.indexOf(element.rel.value) > -1) {
-                g.nodess[element.s.value].isAncestor = true;
-            }
-        }
-        if (undefined !== element.rel && undefined !== element.eq) {
-            if (undefined === g.nodess[element.eq.value] || null === g.nodess[element.eq.value]) {
-                g.nodess[element.eq.value] = new Node(element.eq.value);
-            }
-            if (ancestors.indexOf(element.eq.value) > -1) {
-                g.nodess[element.eq.value].isAncestor = true;
-            }
-            //push to eqIri
-            g.nodess[element.rel.value].eqIri.push(element.eq.value);
-            g.nodess[element.eq.value].eqIri.push(element.rel.value);
-        }
-        if (undefined !== element.der) {
-            if (undefined === g.nodess[element.der.value] || null === g.nodess[element.der.value]) {
-                g.nodess[element.der.value] = new Node(element.der.value);
-            }
-            //add property der
-            g.nodess[element.s.value].der = true;
-        }
-    });
+        return g;
+    };
 
-    //CONSTRUCTING GRAPHNODES
-    //a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
-    //or that refer to the same word - also called here identical Nodes 
-    //(e.g.: if only ee_word and ee_n_word with n an integer belong to                                                                          
-    //the set of ancestors and descendants                                                                                                
-    //then merge them into one graphNode) 
-    //the final graph will use these super nodes (graphNodes)  
-    g.graphNodes = {};
-    var counter = 0; //counts how many graphNodes have been created so far
-    for (var n in g.nodess) {
-        if (g.nodess[n].ety === 0) {
-            var tmp = [];
-            var iso = g.nodess[n].iso;
-            var label = g.nodess[n].label;
-            for (var m in g.nodess) {
-                if (undefined !== g.nodess[m]) {
-                    if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
-                        if (g.nodess[m].ety > 0) {
-                            tmp.push(m);
+    module.drawDAGRE = function(iri, parameter, width, height) {
+        //if parameter == 1 submit a short (but less detailed) query
+        //if parameter == 2 submit a longer (but more detailed) query
+        var url = SPARQL.ENDPOINT + "?query=" + encodeURIComponent(SPARQL.ancestorQuery(iri, parameter));
+        var source;
+        if (LOAD.settings.debug) {
+            console.log(url);
+        }
+        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.loadingMore);
+        d3.select("#tooltipPopup").attr("display", "none");
+        d3.select("#tree-overlay").remove();
+
+        source = SPARQL.getXMLHttpRequest(url);
+
+        source.subscribe(
+            function(response) {
+
+                if (null === response) {
+                    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
+                    return;
+                }
+
+                d3.select("#helpPopup").html(LOAD.HELP.dagre);
+
+                var ancestorArray = JSON.parse(response).results.bindings
+                    .reduce((ancestors, a) => {
+                        ancestors.push(a.ancestor1.value);
+                        if (undefined !== a.ancestor2) {
+                            ancestors.push(a.ancestor2.value);
+                        }
+                        return ancestors;
+                    }, []).filter(onlyUnique);
+
+                console.log("ANCESTORS");
+                console.log(ancestorArray);
+                const subscribe = SPARQL.slicedQuery(ancestorArray, SPARQL.descendantQuery, 8)
+                    .subscribe(
+                        function(val) {
+                            var descendantArray = val.reduce((descendants, d) => {
+                                return descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
+                            }, []);
+                            const subscribe = SPARQL.slicedQuery(descendantArray, SPARQL.propertyQuery, 8)
+                                .subscribe(function(val) {
+                                    var allArray = val.reduce((all, a) => {
+                                        return all.concat(JSON.parse(a).results.bindings);
+                                    }, []);
+                                    if (allArray.length === 0) {
+                                        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.noEtymology);
+                                    } else {
+                                        var g = module.defineGraph(ancestorArray, allArray);
+                                        d3.select("#message").style("display", "none");
+
+                                        var inner = module.renderGraph(g, width, height);
+                                        module.appendLanguageTagTextAndTooltip(inner, g);
+                                        module.appendDefinitionTooltip(inner, g);
+                                    }
+                                });
+                        },
+                        function(error) {
+                            d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
+                            console.log(error);
+                        },
+                        () => console.log('done descendants query'));
+            },
+            function(error) {
+                if (parameter === 1) {
+                    d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.serverError);
+                    console.log(error);
+                } else {
+                    module.drawDAGRE(iri, 1, width, height);
+                }
+            },
+            function() {
+                console.log('done DAGRE' + parameter);
+            });
+    };
+
+    module.defineGraph = function(ancestors, response) {
+        var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+
+        //CONSTRUCTING NODES
+        g.nodess = {};
+        response.forEach(function(element) {
+            //save all nodes        
+            //define isAncestor
+            if (undefined !== element.s && (undefined === g.nodess[element.s.value] || null === g.nodess[element.s.value])) {
+                g.nodess[element.s.value] = new Node(element.s.value);
+                if (ancestors.indexOf(element.s.value) > -1) {
+                    g.nodess[element.s.value].isAncestor = true;
+                }
+            }
+            if (undefined !== element.rel && (undefined === g.nodess[element.rel.value] || null === g.nodess[element.rel.value])) {
+                g.nodess[element.rel.value] = new Node(element.rel.value);
+                if (ancestors.indexOf(element.rel.value) > -1) {
+                    g.nodess[element.s.value].isAncestor = true;
+                }
+            }
+            if (undefined !== element.rel && undefined !== element.eq) {
+                if (undefined === g.nodess[element.eq.value] || null === g.nodess[element.eq.value]) {
+                    g.nodess[element.eq.value] = new Node(element.eq.value);
+                }
+                if (ancestors.indexOf(element.eq.value) > -1) {
+                    g.nodess[element.eq.value].isAncestor = true;
+                }
+                //push to eqIri
+                g.nodess[element.rel.value].eqIri.push(element.eq.value);
+                g.nodess[element.eq.value].eqIri.push(element.rel.value);
+            }
+            if (undefined !== element.der) {
+                if (undefined === g.nodess[element.der.value] || null === g.nodess[element.der.value]) {
+                    g.nodess[element.der.value] = new Node(element.der.value);
+                }
+                //add property der
+                g.nodess[element.s.value].der = true;
+            }
+        });
+
+        //CONSTRUCTING GRAPHNODES
+        //a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
+        //or that refer to the same word - also called here identical Nodes 
+        //(e.g.: if only ee_word and ee_n_word with n an integer belong to                                                                          
+        //the set of ancestors and descendants                                                                                                
+        //then merge them into one graphNode) 
+        //the final graph will use these super nodes (graphNodes)  
+        g.graphNodes = {};
+        var counter = 0; //counts how many graphNodes have been created so far
+        for (var n in g.nodess) {
+            if (g.nodess[n].ety === 0) {
+                var tmp = [];
+                var iso = g.nodess[n].iso;
+                var label = g.nodess[n].label;
+                for (var m in g.nodess) {
+                    if (undefined !== g.nodess[m]) {
+                        if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
+                            if (g.nodess[m].ety > 0) {
+                                tmp.push(m);
+                            }
+                        }
+                    }
+                }
+                tmp = tmp.filter(onlyUnique);
+                //if only ee_word and ee_n_word with n an integer belong to
+                //the set of ancestors and descendants
+                //then merge them in one graphNode
+                if (tmp.length === 1) {
+                    var gg = new GraphNode(counter);
+                    //initialize graphNode.all 
+                    gg.all.push(n);
+                    //define graphNode.iri 
+                    gg.iri = g.nodess[tmp[0]].eqIri;
+                    gg.iri.push(tmp[0]);
+                    //define node.graphNode
+                    g.nodess[n].graphNode.push(counter);
+                    g.nodess[tmp[0]].graphNode.push(counter);
+                    gg.iri.forEach(function(element) {
+                        g.nodess[element].graphNode.push(counter);
+                    });
+
+                    //push to graphNodes
+                    g.graphNodes[counter] = gg;
+                    g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(onlyUnique);
+                    counter++;
+                }
+            }
+        }
+
+        for (var n in g.nodess) {
+            if (g.nodess[n].graphNode.length === 0) {
+                //add iri
+                var gg = new GraphNode(counter);
+                gg.iri = g.nodess[n].eqIri;
+                gg.iri.push(n);
+                var tmp = [];
+                gg.iri.forEach(function(element) {
+                    tmp.concat(element.eqIri);
+                });
+                gg.iri.concat(tmp);
+                gg.iri = gg.iri.filter(onlyUnique);
+                gg.iri.forEach(function(element) {
+                    g.nodess[element].graphNode.push(counter);
+                });
+                g.graphNodes[counter] = gg;
+                counter++;
+            } else {
+                var graphNode = g.nodess[n].graphNode[0];
+
+                g.nodess[n].eqIri.forEach(function(element) {
+                    //add iri
+                    g.nodess[element].graphNode.push(graphNode);
+                    g.graphNodes[graphNode].iri.concat(g.nodess[element].eqIri);
+                    g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(onlyUnique);
+                });
+            }
+        }
+
+        var showDerivedNodes = true;
+        if (ancestors.length < 3) showDerivedNodes = true;
+
+        for (var gg in g.graphNodes) {
+            //define all
+            g.graphNodes[gg].all = g.graphNodes[gg].all.concat(g.graphNodes[gg].iri);
+
+            //define isAncestor
+            if (g.graphNodes[gg].all.filter(function(element) { return g.nodess[element].isAncestor; }).length > 0) {
+                g.graphNodes[gg].isAncestor = true;
+            }
+
+            //define der
+            var der = g.graphNodes[gg].all.filter(function(element) {
+                return g.nodess[element].der !== undefined;
+            });
+            if (der.length > 0) {
+                g.graphNodes[gg].der = true;
+            }
+
+            //define iso, label, lang
+            g.graphNodes[gg].iso = g.nodess[g.graphNodes[gg].all[0]].iso;
+            g.graphNodes[gg].label = g.graphNodes[gg].iri.map(function(i) { return g.nodess[i].label; }).join(",");
+            g.graphNodes[gg].lang = g.nodess[g.graphNodes[gg].all[0]].lang;
+        }
+
+        //define linkedToTarget and linkedToSource
+        response.forEach(function(element) {
+            if (element.rel !== undefined && element.s !== undefined) {
+                var source = g.nodess[element.rel.value].graphNode[0],
+                    target = g.nodess[element.s.value].graphNode[0];
+
+                if (source !== target) {
+                    if (showDerivedNodes) {
+                        g.graphNodes[source].linkedToTarget.push(target);
+                    } else {
+                        //linkedToTarget only counts the number of descendants that are not derived words
+                        if (!(g.graphNodes[source].der || g.graphNodes[target].der)) {
+                            g.graphNodes[source].linkedToTarget.push(target);
+                        }
+                    }
+                    if (g.graphNodes[target].linkedToSource.indexOf(source) === -1) {
+                        g.graphNodes[target].linkedToSource.push(source);
+                    }
+                }
+            }
+        });
+
+        for (var gg in g.graphNodes) {
+            //collapse nodes that have more than 10 descendants and color them differently      
+            if (!showDerivedNodes && g.graphNodes[gg].linkedToTarget.length > 10) {
+                console.log("the following node has more than 10 targets: collapsing");
+                console.log(g.graphNodes[gg]);
+                g.graphNodes[gg].linkedToTarget.map(function(e) {
+                    if (g.graphNodes[e].linkedToSource.length === 1) {
+                        g.graphNodes[e].der = true;
+                    }
+                });
+
+                //    graphNodes[gg].linkedToTarget.map(function(e){  graphNodes[e].der = true; });
+                g.graphNodes[gg].style = "fill: sandyBrown; stroke: lightBlue";
+            }
+        }
+
+        //CONSTRUCTING LINKS
+        var links = [];
+        response.forEach(function(element) {
+            if (undefined !== element.rel && undefined !== element.s) {
+                var source = g.nodess[element.rel.value].graphNode[0],
+                    target = g.nodess[element.s.value].graphNode[0];
+                if (source !== target) {
+                    if (showDerivedNodes || g.graphNodes[target].isAncestor || !(g.graphNodes[source].der || g.graphNodes[target].der)) {
+                        var Link = { "source": source, "target": target };
+                        if (g.graphNodes[target].linkedToSourceCopy.indexOf(source) === -1) {
+                            //define linked and linkedToSourceCopy
+                            links.push(Link);
+                            g.graphNodes[source].linked = true;
+                            g.graphNodes[target].linkedToSourceCopy.push(source);
+                            g.graphNodes[target].linked = true;
                         }
                     }
                 }
             }
-            tmp = tmp.filter(onlyUnique);
-            //if only ee_word and ee_n_word with n an integer belong to
-            //the set of ancestors and descendants
-            //then merge them in one graphNode
-            if (tmp.length === 1) {
-                var gg = new GraphNode(counter);
-                //initialize graphNode.all 
-                gg.all.push(n);
-                //define graphNode.iri 
-                gg.iri = g.nodess[tmp[0]].eqIri;
-                gg.iri.push(tmp[0]);
-                //define node.graphNode
-                g.nodess[n].graphNode.push(counter);
-                g.nodess[tmp[0]].graphNode.push(counter);
-                gg.iri.forEach(function(element) {
-                    g.nodess[element].graphNode.push(counter);
-                });
-
-                //push to graphNodes
-                g.graphNodes[counter] = gg;
-                g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(onlyUnique);
-                counter++;
-            }
-        }
-    }
-
-    for (var n in g.nodess) {
-        if (g.nodess[n].graphNode.length === 0) {
-            //add iri
-            var gg = new GraphNode(counter);
-            gg.iri = g.nodess[n].eqIri;
-            gg.iri.push(n);
-            var tmp = [];
-            gg.iri.forEach(function(element) {
-                tmp.concat(element.eqIri);
-            });
-            gg.iri.concat(tmp);
-            gg.iri = gg.iri.filter(onlyUnique);
-            gg.iri.forEach(function(element) {
-                g.nodess[element].graphNode.push(counter);
-            });
-            g.graphNodes[counter] = gg;
-            counter++;
-        } else {
-            var graphNode = g.nodess[n].graphNode[0];
-
-            g.nodess[n].eqIri.forEach(function(element) {
-                //add iri
-                g.nodess[element].graphNode.push(graphNode);
-                g.graphNodes[graphNode].iri.concat(g.nodess[element].eqIri);
-                g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(onlyUnique);
-            });
-        }
-    }
-
-    var showDerivedNodes = true;
-    if (ancestors.length < 3) showDerivedNodes = true;
-
-    for (var gg in g.graphNodes) {
-        //define all
-        g.graphNodes[gg].all = g.graphNodes[gg].all.concat(g.graphNodes[gg].iri);
-
-        //define isAncestor
-        if (g.graphNodes[gg].all.filter(function(element) { return g.nodess[element].isAncestor; }).length > 0) {
-            g.graphNodes[gg].isAncestor = true;
-        }
-
-        //define der
-        var der = g.graphNodes[gg].all.filter(function(element) {
-            return g.nodess[element].der !== undefined;
         });
-        if (der.length > 0) {
-            g.graphNodes[gg].der = true;
-        }
 
-        //define iso, label, lang
-        g.graphNodes[gg].iso = g.nodess[g.graphNodes[gg].all[0]].iso;
-        g.graphNodes[gg].label = g.graphNodes[gg].iri.map(function(i) { return g.nodess[i].label; }).join(",");
-        g.graphNodes[gg].lang = g.nodess[g.graphNodes[gg].all[0]].lang;
-    }
-
-    //define linkedToTarget and linkedToSource
-    response.forEach(function(element) {
-        if (element.rel !== undefined && element.s !== undefined) {
-            var source = g.nodess[element.rel.value].graphNode[0],
-                target = g.nodess[element.s.value].graphNode[0];
-
-            if (source !== target) {
-                if (showDerivedNodes) {
-                    g.graphNodes[source].linkedToTarget.push(target);
-                } else {
-                    //linkedToTarget only counts the number of descendants that are not derived words
-                    if (!(g.graphNodes[source].der || g.graphNodes[target].der)) {
-                        g.graphNodes[source].linkedToTarget.push(target);
-                    }
-                }
-                if (g.graphNodes[target].linkedToSource.indexOf(source) === -1) {
-                    g.graphNodes[target].linkedToSource.push(source);
-                }
+        //INITIALIZING NODES IN GRAPH
+        //only draw nodes that are linked to other nodes
+        //always show ancestors
+        for (var gg in g.graphNodes) {
+            if (g.graphNodes[gg].linked || g.graphNodes[gg].isAncestor) {
+                g.setNode(gg, g.graphNodes[gg]);
             }
         }
-    });
 
-    for (var gg in g.graphNodes) {
-        //collapse nodes that have more than 10 descendants and color them differently      
-        if (!showDerivedNodes && g.graphNodes[gg].linkedToTarget.length > 10) {
-            console.log("the following node has more than 10 targets: collapsing");
-            console.log(g.graphNodes[gg]);
-            g.graphNodes[gg].linkedToTarget.map(function(e) {
-                if (g.graphNodes[e].linkedToSource.length === 1) {
-                    g.graphNodes[e].der = true;
-                }
-            });
+        //INITIALIZING LINKS IN GRAPH
+        links.forEach(function(element) {
+            g.setEdge(element.source,
+                element.target, { label: "", lineInterpolate: "basis" });
+        });
 
-            //    graphNodes[gg].linkedToTarget.map(function(e){  graphNodes[e].der = true; });
-            g.graphNodes[gg].style = "fill: sandyBrown; stroke: lightBlue";
-        }
-    }
+        return g;
+    };
 
-    //CONSTRUCTING LINKS
-    var links = [];
-    response.forEach(function(element) {
-        if (undefined !== element.rel && undefined !== element.s) {
-            var source = g.nodess[element.rel.value].graphNode[0],
-                target = g.nodess[element.s.value].graphNode[0];
-            if (source !== target) {
-                if (showDerivedNodes || g.graphNodes[target].isAncestor || !(g.graphNodes[source].der || g.graphNodes[target].der)) {
-                    var Link = { "source": source, "target": target };
-                    if (g.graphNodes[target].linkedToSourceCopy.indexOf(source) === -1) {
-                        //define linked and linkedToSourceCopy
-                        links.push(Link);
-                        g.graphNodes[source].linked = true;
-                        g.graphNodes[target].linkedToSourceCopy.push(source);
-                        g.graphNodes[target].linked = true;
-                    }
-                }
-            }
-        }
-    });
+    module.renderGraph = function(g, width, height) {
+        var svg = d3.select("#tree-container").append("svg")
+            .attr("id", "tree-overlay")
+            .attr("width", width)
+            .attr("height", height);
 
-    //INITIALIZING NODES IN GRAPH
-    //only draw nodes that are linked to other nodes
-    //always show ancestors
-    for (var gg in g.graphNodes) {
-        if (g.graphNodes[gg].linked || g.graphNodes[gg].isAncestor) {
-            g.setNode(gg, g.graphNodes[gg]);
-        }
-    }
+        var inner = svg.append("g");
 
-    //INITIALIZING LINKS IN GRAPH
-    links.forEach(function(element) {
-        g.setEdge(element.source,
-            element.target, { label: "", lineInterpolate: "basis" });
-    });
+        // Set up zoom support                      
+        var zoom = d3.behavior.zoom().on("zoom", function() {
+            inner.attr("transform", "translate(" + d3.event.translate + ")" +
+                "scale(" + d3.event.scale + ")");
+        });
+        svg.call(zoom); //.on("dblclick.zoom", null);
 
-    return g;
-}
+        // Create the renderer          
+        var render = new dagreD3.render();
 
-function renderGraph(g, width, height) {
-    var svg = d3.select("#tree-container").append("svg")
-        .attr("id", "tree-overlay")
-        .attr("width", width)
-        .attr("height", height);
+        // Run the renderer. This is what draws the final graph.  
+        render(inner, g);
 
-    var inner = svg.append("g");
+        // Center the graph       
+        var initialScale = 0.75;
+        zoom.translate([(width - g.graph().width * initialScale) / 2, 20])
+            .scale(initialScale)
+            .event(svg);
 
-    // Set up zoom support                      
-    var zoom = d3.behavior.zoom().on("zoom", function() {
-        inner.attr("transform", "translate(" + d3.event.translate + ")" +
-            "scale(" + d3.event.scale + ")");
-    });
-    svg.call(zoom); //.on("dblclick.zoom", null);
+        //svg.attr("height", g.graph().height * initialScale + 40);}}
+        return inner;
+    };
 
-    // Create the renderer          
-    var render = new dagreD3.render();
+    return module;
 
-    // Run the renderer. This is what draws the final graph.  
-    render(inner, g);
-
-    // Center the graph       
-    var initialScale = 0.75;
-    zoom.translate([(width - g.graph().width * initialScale) / 2, 20])
-        .scale(initialScale)
-        .event(svg);
-
-    //svg.attr("height", g.graph().height * initialScale + 40);}}
-    return inner;
-}
+})(GRAPH || {});

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,5 +1,5 @@
 /*globals
-    d3, console, LOAD, dagreD3, GraphNode, DB, Node, Rx, onlyUnique
+    $, d3, console, LOAD, dagreD3, GraphNode, DB, Node, Rx, onlyUnique, window, document
 */
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
 var GRAPH = (function(module) {

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,5 +1,5 @@
 /*globals
-    $, d3, console, LOAD, dagreD3, GraphNode, DB, Node, Rx, onlyUnique, window, document
+    $, d3, console, dagreD3, GraphNode, Node, Rx, onlyUnique, window, document
 */
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
 var GRAPH = (function(module) {
@@ -94,9 +94,9 @@ var GRAPH = (function(module) {
                 n.et.value.split(",")
                     .forEach(function(element) {
                         if (element !== "") {
-                            g.nodess[element] = new Node(element);
+                            g.nodess[element] = new etyBase.LOAD.classes.Node(element);
                         } else {
-                            g.nodess[n.iri.value] = new Node(n.iri.value);
+                            g.nodess[n.iri.value] = new etyBase.LOAD.classes.Node(n.iri.value);
                         }
                     });
             });
@@ -120,7 +120,7 @@ var GRAPH = (function(module) {
         var drawDAGRE = function(iri, parameter, width, height) {
             //if parameter == 1 submit a short (but less detailed) query
             //if parameter == 2 submit a longer (but more detailed) query
-            var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.ancestorQuery(iri, parameter));
+            var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.ancestorQuery(iri, parameter));
             var source;
             if (etyBase.config.debug) {
                 console.log(url);
@@ -203,20 +203,20 @@ var GRAPH = (function(module) {
                 //save all nodes        
                 //define isAncestor
                 if (undefined !== element.s && (undefined === g.nodess[element.s.value] || null === g.nodess[element.s.value])) {
-                    g.nodess[element.s.value] = new Node(element.s.value);
+                    g.nodess[element.s.value] = new etyBase.LOAD.classes.Node(element.s.value);
                     if (ancestors.indexOf(element.s.value) > -1) {
                         g.nodess[element.s.value].isAncestor = true;
                     }
                 }
                 if (undefined !== element.rel && (undefined === g.nodess[element.rel.value] || null === g.nodess[element.rel.value])) {
-                    g.nodess[element.rel.value] = new Node(element.rel.value);
+                    g.nodess[element.rel.value] = new etyBase.LOAD.classes.Node(element.rel.value);
                     if (ancestors.indexOf(element.rel.value) > -1) {
                         g.nodess[element.s.value].isAncestor = true;
                     }
                 }
                 if (undefined !== element.rel && undefined !== element.eq) {
                     if (undefined === g.nodess[element.eq.value] || null === g.nodess[element.eq.value]) {
-                        g.nodess[element.eq.value] = new Node(element.eq.value);
+                        g.nodess[element.eq.value] = new etyBase.LOAD.classes.Node(element.eq.value);
                     }
                     if (ancestors.indexOf(element.eq.value) > -1) {
                         g.nodess[element.eq.value].isAncestor = true;
@@ -227,7 +227,7 @@ var GRAPH = (function(module) {
                 }
                 if (undefined !== element.der) {
                     if (undefined === g.nodess[element.der.value] || null === g.nodess[element.der.value]) {
-                        g.nodess[element.der.value] = new Node(element.der.value);
+                        g.nodess[element.der.value] = new etyBase.LOAD.classes.Node(element.der.value);
                     }
                     //add property der
                     g.nodess[element.s.value].der = true;
@@ -262,7 +262,7 @@ var GRAPH = (function(module) {
                     //the set of ancestors and descendants
                     //then merge them in one graphNode
                     if (tmp.length === 1) {
-                        var gg = new GraphNode(counter);
+                        var gg = new etyBase.LOAD.classes.GraphNode(counter);
                         //initialize graphNode.all 
                         gg.all.push(n);
                         //define graphNode.iri 
@@ -286,7 +286,7 @@ var GRAPH = (function(module) {
             for (var n in g.nodess) {
                 if (g.nodess[n].graphNode.length === 0) {
                     //add iri
-                    var gg = new GraphNode(counter);
+                    var gg = new etyBase.LOAD.classes.GraphNode(counter);
                     gg.iri = g.nodess[n].eqIri;
                     gg.iri.push(n);
                     var tmp = [];
@@ -477,7 +477,7 @@ var GRAPH = (function(module) {
                         }
                         var width = window.innerWidth,
                             height = $(document).height() - $('#header').height();
-                        var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
+                        var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
                         if (etyBase.config.debug) {
                             console.log(url);
                         }

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,5 +1,5 @@
 /*globals
-    $, d3, console, dagreD3, GraphNode, Node, Rx, onlyUnique, window, document
+    $, d3, console, dagreD3, Rx, window, document
 */
 /*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
 var GRAPH = (function(module) {
@@ -148,7 +148,7 @@ var GRAPH = (function(module) {
                                 ancestors.push(a.ancestor2.value);
                             }
                             return ancestors;
-                        }, []).filter(onlyUnique);
+                        }, []).filter(etyBase.helpers.onlyUnique);
 
                     console.log("ANCESTORS");
                     console.log(ancestorArray);
@@ -257,7 +257,7 @@ var GRAPH = (function(module) {
                             }
                         }
                     }
-                    tmp = tmp.filter(onlyUnique);
+                    tmp = tmp.filter(etyBase.helpers.onlyUnique);
                     //if only ee_word and ee_n_word with n an integer belong to
                     //the set of ancestors and descendants
                     //then merge them in one graphNode
@@ -277,7 +277,7 @@ var GRAPH = (function(module) {
 
                         //push to graphNodes
                         g.graphNodes[counter] = gg;
-                        g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(onlyUnique);
+                        g.graphNodes[counter].iri = g.graphNodes[counter].iri.filter(etyBase.helpers.onlyUnique);
                         counter++;
                     }
                 }
@@ -294,7 +294,7 @@ var GRAPH = (function(module) {
                         tmp.concat(element.eqIri);
                     });
                     gg.iri.concat(tmp);
-                    gg.iri = gg.iri.filter(onlyUnique);
+                    gg.iri = gg.iri.filter(etyBase.helpers.onlyUnique);
                     gg.iri.forEach(function(element) {
                         g.nodess[element].graphNode.push(counter);
                     });
@@ -307,7 +307,7 @@ var GRAPH = (function(module) {
                         //add iri
                         g.nodess[element].graphNode.push(graphNode);
                         g.graphNodes[graphNode].iri.concat(g.nodess[element].eqIri);
-                        g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(onlyUnique);
+                        g.graphNodes[graphNode].iri = g.graphNodes[graphNode].iri.filter(etyBase.helpers.onlyUnique);
                     });
                 }
             }

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -446,6 +446,81 @@ var GRAPH = (function(module) {
             return inner;
         };
 
+        var init = function() {
+
+            d3.select("#helpPopup").html(etyBase.LOAD.HELP.intro);
+
+            var div = d3.select("body").append("div")
+                .attr("data-role", "popup")
+                .attr("data-dismissible", "true")
+                .attr("id", "tooltipPopup")
+                .style("display", "none")
+                .attr("class", "ui-content tooltipDiv");
+
+            $(window).click(function() {
+                d3.select("#tooltipPopup")
+                    .style("display", "none");
+            });
+
+            $('#tooltipPopup').click(function(event) {
+                event.stopPropagation();
+            });
+
+            $('#tags').on("keypress click", function(e) {
+                var tag = this;
+                if (e.which === 13 || e.type === 'click') {
+                    var lemma = $(tag).val(); //.replace("/", "!slash!");
+
+                    if (lemma) {
+                        if (etyBase.LOAD.settings.debug) {
+                            console.log("searching lemma in database");
+                        }
+                        var width = window.innerWidth,
+                            height = $(document).height() - $('#header').height();
+                        var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
+                        if (etyBase.LOAD.settings.debug) {
+                            console.log(url);
+                        }
+
+                        const source = etyBase.DB.getXMLHttpRequest(url);
+                        source.subscribe(
+                            function(response) {
+                                if (response !== undefined && response !== null) {
+                                    d3.select("#tree-overlay").remove();
+                                    d3.select("#tooltipPopup").style("display", "none");
+
+                                    var g = etyBase.GRAPH.buildDisambiguationDAGRE(response);
+                                    if (null === g) {
+                                        d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
+                                    } else {
+                                        if (Object.keys(g.nodess).length > 1) {
+                                            d3.select("#helpPopup").html(etyBase.LOAD.HELP.disambiguation);
+                                            d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
+                                            var inner = etyBase.GRAPH.renderGraph(g, width, height);
+                                            etyBase.GRAPH.appendLanguageTagTextAndTooltip(inner, g);
+                                            etyBase.GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
+
+                                            d3.selectAll(".edgePath").remove();
+                                        } else {
+                                            var iri = Object.keys(g.nodess)[0];
+                                            etyBase.GRAPH.drawDAGRE(iri, 2, width, height);
+                                        }
+                                    }
+                                }
+                            },
+                            function(error) {
+                                console.error(error);
+                                d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
+                            },
+                            () => console.log('done disambiguation'));
+                    }
+                }
+            });
+
+
+        };
+
+        this.init = init;
         this.appendLanguageTagTextAndTooltip = appendLanguageTagTextAndTooltip;
         this.appendDefinitionTooltip = appendDefinitionTooltip;
         this.appendDefinitionTooltipOrDrawDAGRE = appendDefinitionTooltipOrDrawDAGRE;

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -15,7 +15,10 @@ var EtyTree = {
         };
         etyBase.config = {
             modules: ['DB', 'GRAPH', 'LOAD'],
-            debug: false
+            debug: false,
+            urls: {
+                ENDPOINT: "https://etytree-virtuoso.wmflabs.org/sparql"
+            }
         };
         bindModules(etyBase, etyBase.config.modules);
         return etyBase;

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -9,16 +9,21 @@ var EtyTree = {
                 window[modules[i]].bindModule(base, modules[i]);
             }
         };
-        var modules = ['DB', 'GRAPH', 'LOAD'];
-        bindModules(etyBase, modules);
+        etyBase.config = {
+            modules: ['DB', 'GRAPH', 'LOAD']
+        };
+        bindModules(etyBase, etyBase.config.modules);
         return etyBase;
     },
     init: function() {
         var etyBase = this;
-        
-        /* Run LOAD's init function -- Should this be called differently? */
-        etyBase.LOAD.init();
-        etyBase.GRAPH.init();
+
+        /* Load init function for every module */
+        etyBase.config.modules.forEach((moduleName) => {
+            if (etyBase[moduleName] && (typeof etyBase[moduleName].init === 'function')) {
+                etyBase[moduleName].init();
+            }
+        });
     }
 };
 

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -1,5 +1,5 @@
 /*globals
-    jQuery, $, d3, LOAD, console, window, document, DB, GRAPH
+    jQuery, $, d3, console, window
 */
 var EtyTree = {
     create: function() {
@@ -18,76 +18,7 @@ var EtyTree = {
         
         /* Run LOAD's init function -- Should this be called differently? */
         etyBase.LOAD.init();
-
-        d3.select("#helpPopup").html(etyBase.LOAD.HELP.intro);
-
-        var div = d3.select("body").append("div")
-            .attr("data-role", "popup")
-            .attr("data-dismissible", "true")
-            .attr("id", "tooltipPopup")
-            .style("display", "none")
-            .attr("class", "ui-content tooltipDiv");
-
-        $(window).click(function() {
-            d3.select("#tooltipPopup")
-                .style("display", "none");
-        });
-
-        $('#tooltipPopup').click(function(event) {
-            event.stopPropagation();
-        });
-
-        $('#tags').on("keypress click", function(e) {
-            var tag = this;
-            if (e.which === 13 || e.type === 'click') {
-                var lemma = $(tag).val(); //.replace("/", "!slash!");
-
-                if (lemma) {
-                    if (etyBase.LOAD.settings.debug) {
-                        console.log("searching lemma in database");
-                    }
-                    var width = window.innerWidth,
-                        height = $(document).height() - $('#header').height();
-                    var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
-                    if (etyBase.LOAD.settings.debug) {
-                        console.log(url);
-                    }
-
-                    const source = etyBase.DB.getXMLHttpRequest(url);
-                    source.subscribe(
-                        function(response) {
-                            if (response !== undefined && response !== null) {
-                                d3.select("#tree-overlay").remove();
-                                d3.select("#tooltipPopup").style("display", "none");
-
-                                var g = etyBase.GRAPH.buildDisambiguationDAGRE(response);
-                                if (null === g) {
-                                    d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
-                                } else {
-                                    if (Object.keys(g.nodess).length > 1) {
-                                        d3.select("#helpPopup").html(etyBase.LOAD.HELP.disambiguation);
-                                        d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
-                                        var inner = etyBase.GRAPH.renderGraph(g, width, height);
-                                        etyBase.GRAPH.appendLanguageTagTextAndTooltip(inner, g);
-                                        etyBase.GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
-
-                                        d3.selectAll(".edgePath").remove();
-                                    } else {
-                                        var iri = Object.keys(g.nodess)[0];
-                                        etyBase.GRAPH.drawDAGRE(iri, 2, width, height);
-                                    }
-                                }
-                            }
-                        },
-                        function(error) {
-                            console.error(error);
-                            d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
-                        },
-                        () => console.log('done disambiguation'));
-                }
-            }
-        });
-
+        etyBase.GRAPH.init();
     }
 };
 

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -14,7 +14,8 @@ var EtyTree = {
             }
         };
         etyBase.config = {
-            modules: ['DB', 'GRAPH', 'LOAD']
+            modules: ['DB', 'GRAPH', 'LOAD'],
+            debug: false
         };
         bindModules(etyBase, etyBase.config.modules);
         return etyBase;

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -6,6 +6,10 @@ var EtyTree = {
         var etyBase = Object.create(this);
         var bindModules = function(base, modules) {
             for (var i = modules.length - 1; i >= 0; i--) {
+                if (!window[modules[i]]) {
+                    console.error('Module ' + modules[i] + 'is not loaded.');
+                    return false;
+                }
                 window[modules[i]].bindModule(base, modules[i]);
             }
         };

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -1,5 +1,5 @@
 /*globals
-    jQuery, d3, LOAD, console, window, document, SPARQL, GRAPH
+    jQuery, d3, LOAD, console, window, document, DB, GRAPH
 */
 jQuery('document').ready(function($) {
     d3.select("#helpPopup").html(LOAD.HELP.intro);
@@ -30,12 +30,12 @@ jQuery('document').ready(function($) {
                 }
                 var width = window.innerWidth,
                     height = $(document).height() - $('#header').height();
-                var url = SPARQL.ENDPOINT + "?query=" + encodeURIComponent(SPARQL.disambiguationQuery(lemma));
+                var url = DB.ENDPOINT + "?query=" + encodeURIComponent(DB.disambiguationQuery(lemma));
                 if (LOAD.settings.debug) {
                     console.log(url);
                 }
 
-                const source = SPARQL.getXMLHttpRequest(url);
+                const source = DB.getXMLHttpRequest(url);
                 source.subscribe(
                     function(response) {
                         if (response !== undefined && response !== null) {

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -1,72 +1,91 @@
 /*globals
-    jQuery, d3, LOAD, console, window, document, DB, GRAPH
+    jQuery, $, d3, LOAD, console, window, document, DB, GRAPH
 */
-jQuery('document').ready(function($) {
-    d3.select("#helpPopup").html(LOAD.HELP.intro);
+var EtyTree = {
+    create: function() {
+        var etytree = Object.create(this);
+        etytree.DB = DB;
+        etytree.GRAPH = GRAPH;
+        etytree.LOAD = LOAD;
+        return etytree;
+    },
+    init: function() {
+        var that = this;
+        d3.select("#helpPopup").html(that.LOAD.HELP.intro);
 
-    var div = d3.select("body").append("div")
-        .attr("data-role", "popup")
-        .attr("data-dismissible", "true")
-        .attr("id", "tooltipPopup")
-        .style("display", "none")
-        .attr("class", "ui-content tooltipDiv");
+        var div = d3.select("body").append("div")
+            .attr("data-role", "popup")
+            .attr("data-dismissible", "true")
+            .attr("id", "tooltipPopup")
+            .style("display", "none")
+            .attr("class", "ui-content tooltipDiv");
 
-    $(window).click(function() {
-        d3.select("#tooltipPopup")
-            .style("display", "none");
-    });
+        $(window).click(function() {
+            d3.select("#tooltipPopup")
+                .style("display", "none");
+        });
 
-    $('#tooltipPopup').click(function(event) {
-        event.stopPropagation();
-    });
+        $('#tooltipPopup').click(function(event) {
+            event.stopPropagation();
+        });
 
-    $('#tags').on("keypress click", function(e) {
-        if (e.which === 13 || e.type === 'click') {
-            var lemma = $(this).val(); //.replace("/", "!slash!");
+        $('#tags').on("keypress click", function(e) {
+            var tag = this;
+            if (e.which === 13 || e.type === 'click') {
+                var lemma = $(tag).val(); //.replace("/", "!slash!");
 
-            if (lemma) {
-                if (LOAD.settings.debug) {
-                    console.log("searching lemma in database");
-                }
-                var width = window.innerWidth,
-                    height = $(document).height() - $('#header').height();
-                var url = DB.ENDPOINT + "?query=" + encodeURIComponent(DB.disambiguationQuery(lemma));
-                if (LOAD.settings.debug) {
-                    console.log(url);
-                }
+                if (lemma) {
+                    if (that.LOAD.settings.debug) {
+                        console.log("searching lemma in database");
+                    }
+                    var width = window.innerWidth,
+                        height = $(document).height() - $('#header').height();
+                    var url = that.DB.ENDPOINT + "?query=" + encodeURIComponent(that.DB.disambiguationQuery(lemma));
+                    if (that.LOAD.settings.debug) {
+                        console.log(url);
+                    }
 
-                const source = DB.getXMLHttpRequest(url);
-                source.subscribe(
-                    function(response) {
-                        if (response !== undefined && response !== null) {
-                            d3.select("#tree-overlay").remove();
-                            d3.select("#tooltipPopup").style("display", "none");
+                    const source = that.DB.getXMLHttpRequest(url);
+                    source.subscribe(
+                        function(response) {
+                            if (response !== undefined && response !== null) {
+                                d3.select("#tree-overlay").remove();
+                                d3.select("#tooltipPopup").style("display", "none");
 
-                            var g = GRAPH.buildDisambiguationDAGRE(response);
-                            if (null === g) {
-                                d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.notAvailable);
-                            } else {
-                                if (Object.keys(g.nodess).length > 1) {
-                                    d3.select("#helpPopup").html(LOAD.HELP.disambiguation);
-                                    d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
-                                    var inner = GRAPH.renderGraph(g, width, height);
-                                    GRAPH.appendLanguageTagTextAndTooltip(inner, g);
-                                    GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
-
-                                    d3.selectAll(".edgePath").remove();
+                                var g = that.GRAPH.buildDisambiguationDAGRE(response);
+                                if (null === g) {
+                                    d3.select("#message").style("display", "inline").html(that.LOAD.MESSAGE.notAvailable);
                                 } else {
-                                    var iri = Object.keys(g.nodess)[0];
-                                    GRAPH.drawDAGRE(iri, 2, width, height);
+                                    if (Object.keys(g.nodess).length > 1) {
+                                        d3.select("#helpPopup").html(that.LOAD.HELP.disambiguation);
+                                        d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
+                                        var inner = that.GRAPH.renderGraph(g, width, height);
+                                        that.GRAPH.appendLanguageTagTextAndTooltip(inner, g);
+                                        that.GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
+
+                                        d3.selectAll(".edgePath").remove();
+                                    } else {
+                                        var iri = Object.keys(g.nodess)[0];
+                                        that.GRAPH.drawDAGRE(iri, 2, width, height);
+                                    }
                                 }
                             }
-                        }
-                    },
-                    function(error) {
-                        console.error(error);
-                        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.notAvailable);
-                    },
-                    () => console.log('done disambiguation'));
+                        },
+                        function(error) {
+                            console.error(error);
+                            d3.select("#message").style("display", "inline").html(that.LOAD.MESSAGE.notAvailable);
+                        },
+                        () => console.log('done disambiguation'));
+                }
             }
-        }
-    });
+        });
+
+    }
+};
+
+var ety;
+
+jQuery('document').ready(function($) {
+    ety = EtyTree.create();
+    ety.init();
 });

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -1,5 +1,5 @@
 /*globals
-    jQuery, d3, LOAD, console, window, document, SPARQL, drawDisambiguation, buildDisambiguationDAGRE, renderGraph, drawDAGRE, appendDefinitionTooltipOrDrawDAGRE, appendLanguageTagTextAndTooltip
+    jQuery, d3, LOAD, console, window, document, SPARQL, GRAPH
 */
 jQuery('document').ready(function($) {
     d3.select("#helpPopup").html(LOAD.HELP.intro);
@@ -37,35 +37,35 @@ jQuery('document').ready(function($) {
 
                 const source = SPARQL.getXMLHttpRequest(url);
                 source.subscribe(
-				            function(response) {
-				                if (response !== undefined && response !== null) { 
-					                  d3.select("#tree-overlay").remove();
-					                  d3.select("#tooltipPopup").style("display", "none");
-					 
-					                  var g = buildDisambiguationDAGRE(response);
-					                  if (null === g) { 
-					                      d3.select("#message").style("display", "inline").html(MESSAGE.notAvailable);
-					                  } else {
-					                      if (Object.keys(g.nodess).length > 1) {
-						                        d3.select("#helpPopup").html(LOAD.HELP.disambiguation);  
-						                        d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
-						                        var inner = renderGraph(g, width, height);
-						                        appendLanguageTagTextAndTooltip(inner, g);
-						                        appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
-						 
-						                        d3.selectAll(".edgePath").remove();
-					                      } else {    
-						                        var iri = Object.keys(g.nodess)[0];
-						                        drawDAGRE(iri, 2, width, height);   
-					                      }
-					                  }
-				                }
-				            },
-				            function(error){ 
-				                console.error(error);
-				                d3.select("#message").style("display", "inline").html(MESSAGE.notAvailable);
-				            },
-				            () => console.log('done disambiguation'));
+                    function(response) {
+                        if (response !== undefined && response !== null) {
+                            d3.select("#tree-overlay").remove();
+                            d3.select("#tooltipPopup").style("display", "none");
+
+                            var g = GRAPH.buildDisambiguationDAGRE(response);
+                            if (null === g) {
+                                d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.notAvailable);
+                            } else {
+                                if (Object.keys(g.nodess).length > 1) {
+                                    d3.select("#helpPopup").html(LOAD.HELP.disambiguation);
+                                    d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
+                                    var inner = GRAPH.renderGraph(g, width, height);
+                                    GRAPH.appendLanguageTagTextAndTooltip(inner, g);
+                                    GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
+
+                                    d3.selectAll(".edgePath").remove();
+                                } else {
+                                    var iri = Object.keys(g.nodess)[0];
+                                    GRAPH.drawDAGRE(iri, 2, width, height);
+                                }
+                            }
+                        }
+                    },
+                    function(error) {
+                        console.error(error);
+                        d3.select("#message").style("display", "inline").html(LOAD.MESSAGE.notAvailable);
+                    },
+                    () => console.log('done disambiguation'));
             }
         }
     });

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -4,6 +4,18 @@
 var EtyTree = {
     create: function() {
         var etyBase = Object.create(this);
+
+        //HELPER FUNCTIONS
+        etyBase.helpers = {
+            onlyUnique: function(value, index, self) {
+                return self.indexOf(value) === index;
+            },
+            transform: function(d) {
+                return "translate(" + d.x + "," + d.y + ")";
+            }
+        };
+
+        /* Binding Modules */
         var bindModules = function(base, modules) {
             for (var i = modules.length - 1; i >= 0; i--) {
                 if (!window[modules[i]]) {
@@ -13,6 +25,8 @@ var EtyTree = {
                 window[modules[i]].bindModule(base, modules[i]);
             }
         };
+
+        /* Setup basic settings */
         etyBase.config = {
             modules: ['DB', 'GRAPH', 'LOAD'],
             debug: false,
@@ -20,11 +34,14 @@ var EtyTree = {
                 ENDPOINT: "https://etytree-virtuoso.wmflabs.org/sparql"
             }
         };
+
         bindModules(etyBase, etyBase.config.modules);
         return etyBase;
     },
     init: function() {
         var etyBase = this;
+
+        etyBase.tree = {}; // This will get populated with data, LangMap, inner, g, and some other key items
 
         /* Load init function for every module */
         etyBase.config.modules.forEach((moduleName) => {

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -60,7 +60,7 @@ var LOAD = (function(module) {
                 //ety is an integer                              
                 //and represents the etymology number encoded in the iri;
                 this.ety = tmp.ety;
-                this.lang = etyBase.LOAD.langMap.get(this.iso);
+                this.lang = etyBase.tree.langMap.get(this.iso);
                 //graphNode specifies the graphNode(s) corresponding to the node                           
                 this.graphNode = [];
                 //eqIri is an array of iri-s of Node-s that are equivalent to the Node             
@@ -197,23 +197,23 @@ var LOAD = (function(module) {
                 console.log("loading languages");
             }
 
-            etyBase.LOAD.langMap = new Map();
+            etyBase.tree.langMap = new Map();
             var ssv = d3.dsv(";", "text/plain");
             ssv("./resources/data/etymology-only_languages.csv", function(data) {
                 data.forEach(function(entry) {
-                    etyBase.LOAD.langMap.set(entry.code, entry["canonical name"]);
+                    etyBase.tree.langMap.set(entry.code, entry["canonical name"]);
                 });
             });
             ssv("./resources/data/list_of_languages.csv", function(data) {
                 data.forEach(function(entry) {
-                    etyBase.LOAD.langMap.set(entry.code, entry["canonical name"]);
+                    etyBase.tree.langMap.set(entry.code, entry["canonical name"]);
                 });
             });
             d3.text("./resources/data/iso-639-3.tab", function(error, textString) {
                 var headers = ["Id", "Part2B", "Part2T", "Part1", "Scope", "Language_Type", "Ref_Name", "Comment"].join("\t");
                 var data = d3.tsv.parse(headers + textString);
                 data.forEach(function(entry) {
-                    etyBase.LOAD.langMap.set(entry.Id, entry.Ref_Name);
+                    etyBase.tree.langMap.set(entry.Id, entry.Ref_Name);
                 });
             });
         };
@@ -232,12 +232,3 @@ var LOAD = (function(module) {
     return module;
 
 })(LOAD || {});
-
-//HELPER FUNCTIONS
-function onlyUnique(value, index, self) {
-    return self.indexOf(value) === index;
-}
-
-function transform(d) {
-    return "translate(" + d.x + "," + d.y + ")";
-}

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -6,9 +6,6 @@ var LOAD = (function(module) {
     module.bindModule = function(base, moduleName) {
         var etyBase = base;
 
-        var settings = {
-            debug: false
-        };
         var HELP = {
             intro: "Enter a word in the search bar, then press enter or click.",
             disambiguation: "<b>Disambiguation page</b>" +
@@ -35,32 +32,31 @@ var LOAD = (function(module) {
         var init = function() {
             //LOAD LANGUAGES
             //used to print on screen the language name when the user clicks on a node (e.g.: eng -> "English")      
-            if (module.settings.debug) {
+            if (etyBase.config.debug) {
                 console.log("loading languages");
             }
 
-            module.langMap = new Map();
+            etyBase.LOAD.langMap = new Map();
             var ssv = d3.dsv(";", "text/plain");
             ssv("./resources/data/etymology-only_languages.csv", function(data) {
                 data.forEach(function(entry) {
-                    module.langMap.set(entry.code, entry["canonical name"]);
+                    etyBase.LOAD.langMap.set(entry.code, entry["canonical name"]);
                 });
             });
             ssv("./resources/data/list_of_languages.csv", function(data) {
                 data.forEach(function(entry) {
-                    module.langMap.set(entry.code, entry["canonical name"]);
+                    etyBase.LOAD.langMap.set(entry.code, entry["canonical name"]);
                 });
             });
             d3.text("./resources/data/iso-639-3.tab", function(error, textString) {
                 var headers = ["Id", "Part2B", "Part2T", "Part1", "Scope", "Language_Type", "Ref_Name", "Comment"].join("\t");
                 var data = d3.tsv.parse(headers + textString);
                 data.forEach(function(entry) {
-                    module.langMap.set(entry.Id, entry.Ref_Name);
+                    etyBase.LOAD.langMap.set(entry.Id, entry.Ref_Name);
                 });
             });
         };
 
-        this.settings = settings;
         this.HELP = HELP;
         this.MESSAGE = MESSAGE;
         this.init = init;

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -2,58 +2,70 @@
     d3, Rx, DB, console, XMLHttpRequest
 */
 var LOAD = (function(module) {
-    module.settings = {
-        debug: false
-    };
-    module.HELP = {
-        intro: "Enter a word in the search bar, then press enter or click.",
-        disambiguation: "<b>Disambiguation page</b>" +
-            "<br>Pick the word you are interested in." +
-            "<ul>" +
-            "<li>Mouse over a node to display lexical information</li>" +
-            "<li>Mouse over the language tag under the node to display the language</li>" +
-            "<li>Click on a node to choose a word</li>" +
-            "</ul>",
-        dagre: "Arrows go from ancestor to descendant.<ul>" +
-            "<li>Mouse over a node to display lexical information</li>" +
-            "<li>Mouse over the language tag under the node to display the language</li>" +
-            "</ul>"
-    };
 
-    module.MESSAGE = {
-        notAvailable: "This word is not available in the database.",
-        loading: "Loading, please wait...",
-        serverError: "Sorry, the server cannot extract etymological relationships correctly for this word.",
-        noEtymology: "Sorry, it seems like no etymology is available in the English Wiktionary for this word.",
-        loadingMore: "Loading, please wait... This word is etymologically related to many words."
-    };
+    module.bindModule = function(base, moduleName) {
+        var etyBase = base;
 
-    module.init = function() {
-        //LOAD LANGUAGES
-        //used to print on screen the language name when the user clicks on a node (e.g.: eng -> "English")      
-        if (module.settings.debug) {
-            console.log("loading languages");
-        }
+        var settings = {
+            debug: false
+        };
+        var HELP = {
+            intro: "Enter a word in the search bar, then press enter or click.",
+            disambiguation: "<b>Disambiguation page</b>" +
+                "<br>Pick the word you are interested in." +
+                "<ul>" +
+                "<li>Mouse over a node to display lexical information</li>" +
+                "<li>Mouse over the language tag under the node to display the language</li>" +
+                "<li>Click on a node to choose a word</li>" +
+                "</ul>",
+            dagre: "Arrows go from ancestor to descendant.<ul>" +
+                "<li>Mouse over a node to display lexical information</li>" +
+                "<li>Mouse over the language tag under the node to display the language</li>" +
+                "</ul>"
+        };
 
-        module.langMap = new Map();
-        var ssv = d3.dsv(";", "text/plain");
-        ssv("./resources/data/etymology-only_languages.csv", function(data) {
-            data.forEach(function(entry) {
-                module.langMap.set(entry.code, entry["canonical name"]);
+        var MESSAGE = {
+            notAvailable: "This word is not available in the database.",
+            loading: "Loading, please wait...",
+            serverError: "Sorry, the server cannot extract etymological relationships correctly for this word.",
+            noEtymology: "Sorry, it seems like no etymology is available in the English Wiktionary for this word.",
+            loadingMore: "Loading, please wait... This word is etymologically related to many words."
+        };
+
+        var init = function() {
+            //LOAD LANGUAGES
+            //used to print on screen the language name when the user clicks on a node (e.g.: eng -> "English")      
+            if (module.settings.debug) {
+                console.log("loading languages");
+            }
+
+            module.langMap = new Map();
+            var ssv = d3.dsv(";", "text/plain");
+            ssv("./resources/data/etymology-only_languages.csv", function(data) {
+                data.forEach(function(entry) {
+                    module.langMap.set(entry.code, entry["canonical name"]);
+                });
             });
-        });
-        ssv("./resources/data/list_of_languages.csv", function(data) {
-            data.forEach(function(entry) {
-                module.langMap.set(entry.code, entry["canonical name"]);
+            ssv("./resources/data/list_of_languages.csv", function(data) {
+                data.forEach(function(entry) {
+                    module.langMap.set(entry.code, entry["canonical name"]);
+                });
             });
-        });
-        d3.text("./resources/data/iso-639-3.tab", function(error, textString) {
-            var headers = ["Id", "Part2B", "Part2T", "Part1", "Scope", "Language_Type", "Ref_Name", "Comment"].join("\t");
-            var data = d3.tsv.parse(headers + textString);
-            data.forEach(function(entry) {
-                module.langMap.set(entry.Id, entry.Ref_Name);
+            d3.text("./resources/data/iso-639-3.tab", function(error, textString) {
+                var headers = ["Id", "Part2B", "Part2T", "Part1", "Scope", "Language_Type", "Ref_Name", "Comment"].join("\t");
+                var data = d3.tsv.parse(headers + textString);
+                data.forEach(function(entry) {
+                    module.langMap.set(entry.Id, entry.Ref_Name);
+                });
             });
-        });
+        };
+
+        this.settings = settings;
+        this.HELP = HELP;
+        this.MESSAGE = MESSAGE;
+        this.init = init;
+
+        etyBase[moduleName] = this;
     };
 
     return module;
@@ -229,5 +241,3 @@ class Node {
             }).join(", ");
     }
 }
-
-LOAD.init();

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -1,5 +1,5 @@
 /*globals 
-    d3, Rx, SPARQL, console, XMLHttpRequest
+    d3, Rx, DB, console, XMLHttpRequest
 */
 var LOAD = (function(module) {
     module.settings = {
@@ -115,8 +115,8 @@ class Node {
     }
 
     logTooltip() {
-        var query = SPARQL.lemmaQuery(this.iri);
-        var url = SPARQL.ENDPOINT + "?query=" + encodeURIComponent(query);
+        var query = DB.lemmaQuery(this.iri);
+        var url = DB.ENDPOINT + "?query=" + encodeURIComponent(query);
 
         if (LOAD.settings.debug) {
             console.log(url);
@@ -124,7 +124,7 @@ class Node {
 
         var that = this;
 
-        const source = SPARQL.getXMLHttpRequest(url);
+        const source = DB.getXMLHttpRequest(url);
         source.subscribe(
             function(response) {
                 var text = "<b>" + that.label + "</b><br><br><br>";

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -76,7 +76,7 @@ var LOAD = (function(module) {
 
             logTooltip() {
                 var query = etyBase.DB.lemmaQuery(this.iri);
-                var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(query);
+                var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(query);
 
                 if (etyBase.config.debug) {
                     console.log(url);

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -6,8 +6,6 @@ var DB = (function(module) {
     module.bindModule = function(base, moduleName) {
         var etyBase = base;
 
-        var ENDPOINT = "https://etytree-virtuoso.wmflabs.org/sparql";
-
         var getXMLHttpRequest = function(url) {
             return Rx.Observable.create(observer => {
                 const req = new XMLHttpRequest();
@@ -36,7 +34,7 @@ var DB = (function(module) {
             for (i = 0, j = myArray.length; i < j; i += chunk) {
                 tmpArray = myArray.slice(i, i + chunk);
                 //console.log(DB.unionQuery(tmpArray, query));                   
-                url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.unionQuery(tmpArray, queryFunction));
+                url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.unionQuery(tmpArray, queryFunction));
                 if (etyBase.config.debug) {
                     console.log(url);
                 }
@@ -188,7 +186,6 @@ var DB = (function(module) {
             return query;
         };
 
-        this.ENDPOINT = ENDPOINT;
         this.getXMLHttpRequest = getXMLHttpRequest;
         this.slicedQuery = slicedQuery;
         this.disambiguationQuery = disambiguationQuery;

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -37,7 +37,7 @@ var DB = (function(module) {
                 tmpArray = myArray.slice(i, i + chunk);
                 //console.log(DB.unionQuery(tmpArray, query));                   
                 url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.unionQuery(tmpArray, queryFunction));
-                if (etyBase.LOAD.settings.debug) {
+                if (etyBase.config.debug) {
                     console.log(url);
                 }
                 sources.push(etyBase.DB.getXMLHttpRequest(url));

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -1,5 +1,5 @@
 /*globals
-    $, Rx, XMLHttpRequest, console, d3, window, document
+    Rx, XMLHttpRequest, console, d3
 */
 var DB = (function(module) {
 

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -1,188 +1,204 @@
 /*globals
-    Rx, XMLHttpRequest, console, d3, MESSAGE, LOAD
+    Rx, XMLHttpRequest, console, d3
 */
 var DB = (function(module) {
 
-    module.ENDPOINT = "https://etytree-virtuoso.wmflabs.org/sparql";
+    module.bindModule = function(base, moduleName) {
+        var etyBase = base;
 
-    module.getXMLHttpRequest = function(url) {
-        return Rx.Observable.create(observer => {
-            const req = new XMLHttpRequest();
-            req.open('GET', url);
-            req.overrideMimeType('application/sparql-results+json');
-            req.onload = () => {
-                if (req.status === 200) {
-                    observer.next(req.responseText);
-                    observer.complete();
-                } else {
-                    observer.error(new Error(req.statusText));
-                }
-            };
-            req.onerror = () => {
-                observer.error(new Error('An error occured'));
-            };
-            req.setRequestHeader('Accept', 'application/json, text/javascript');
-            req.send();
-        });
-    };
+        var ENDPOINT = "https://etytree-virtuoso.wmflabs.org/sparql";
 
-    //function to slice up a big sparql query (that cannot be processed by virtuoso)                     
-    // into a bunch of smaller queries in chunks of "chunk"                                             
-    module.slicedQuery = function(myArray, queryFunction, chunk) {
-        var i, j, tmpArray, url, sources = [];
-        for (i = 0, j = myArray.length; i < j; i += chunk) {
-            tmpArray = myArray.slice(i, i + chunk);
-            //console.log(DB.unionQuery(tmpArray, query));                   
-            url = this.ENDPOINT + "?query=" + encodeURIComponent(this.unionQuery(tmpArray, queryFunction));
-            if (LOAD.settings.debug) {
-                console.log(url);
-            }
-            sources.push(this.getXMLHttpRequest(url));
-        }
-        const queryObservable = Rx.Observable.zip.apply(this, sources)
-            .catch((err) => {
-                d3.select("#message").html(LOAD.MESSAGE.serverError);
-
-                //Return an empty Observable which gets collapsed in the output             
-                return Rx.Observable.empty();
+        var getXMLHttpRequest = function(url) {
+            return Rx.Observable.create(observer => {
+                const req = new XMLHttpRequest();
+                req.open('GET', url);
+                req.overrideMimeType('application/sparql-results+json');
+                req.onload = () => {
+                    if (req.status === 200) {
+                        observer.next(req.responseText);
+                        observer.complete();
+                    } else {
+                        observer.error(new Error(req.statusText));
+                    }
+                };
+                req.onerror = () => {
+                    observer.error(new Error('An error occured'));
+                };
+                req.setRequestHeader('Accept', 'application/json, text/javascript');
+                req.send();
             });
-        return queryObservable;
-    };
+        };
+
+        //function to slice up a big sparql query (that cannot be processed by virtuoso)                     
+        // into a bunch of smaller queries in chunks of "chunk"                                             
+        var slicedQuery = function(myArray, queryFunction, chunk) {
+            var i, j, tmpArray, url, sources = [];
+            for (i = 0, j = myArray.length; i < j; i += chunk) {
+                tmpArray = myArray.slice(i, i + chunk);
+                //console.log(DB.unionQuery(tmpArray, query));                   
+                url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.unionQuery(tmpArray, queryFunction));
+                if (etyBase.LOAD.settings.debug) {
+                    console.log(url);
+                }
+                sources.push(etyBase.DB.getXMLHttpRequest(url));
+            }
+            const queryObservable = Rx.Observable.zip.apply(this, sources)
+                .catch((err) => {
+                    d3.select("#message").html(etyBase.LOAD.MESSAGE.serverError);
+
+                    //Return an empty Observable which gets collapsed in the output             
+                    return Rx.Observable.empty();
+                });
+            return queryObservable;
+        };
 
 
-    module.disambiguationQuery = function(lemma) {
-        var encodedWord = lemma.replace(/'/g, "\\\\'").replace("·", "%C2%B7");
-        var query =
-            "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> " +
-            "PREFIX dbnary: <http://kaiko.getalp.org/dbnary#> " +
-            "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
-            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
-            "SELECT DISTINCT ?iri (group_concat(distinct ?ee ; separator=\",\") as ?et) " +
-            "WHERE { " +
-            "    ?iri rdfs:label ?label . ?label bif:contains \"\'" + encodedWord + "\'\" . " +
-            //exclude entries that contain the searched word but include other words
-            //(e.g.: search="door" label="doorbell", exclude "doorbell")
-            "    FILTER REGEX(?label, \"^" + encodedWord + "$\", 'i') . " +
-            "    ?iri rdf:type dbetym:EtymologyEntry . " +
-            "    OPTIONAL { " +
-            "        ?iri dbnary:describes  ?ee . " +
-            "        ?ee rdf:type dbetym:EtymologyEntry . " +
-            "    } " +
-            "} ";
-
-        return query;
-    };
-
-    //DEFINE QUERY TO GET LINKS, POS AND GLOSS           
-    module.lemmaQuery = function(iri) {
-        var query =
-            "PREFIX dbnary: <http://kaiko.getalp.org/dbnary#> " +
-            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
-            "PREFIX lexinfo: <http://www.lexinfo.net/ontology/2.0/lexinfo#> " +
-            "PREFIX skos: <http://www.w3.org/2004/02/skos/core#> " +
-            "PREFIX ontolex: <http://www.w3.org/ns/lemon/ontolex#> " +
-            "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
-            "SELECT DISTINCT ?ee ?pos (group_concat(distinct ?def ; separator=\";;;;\") as ?gloss) (group_concat(distinct ?also ; separator=\",\") as ?links) " +
-            "WHERE { " +
-            "    <" + iri.replace(/__ee_[0-9]+_/g, "__ee_") + "> rdfs:seeAlso ?also . " +
-            "    OPTIONAL { " +
-            "        <" + iri + "> dbnary:describes ?ee . " +
-            "        OPTIONAL { " +
-            "            ?ee rdf:type ontolex:LexicalEntry . " +
-            "            ?ee dbnary:partOfSpeech ?pos . " +
-            "        } " +
-            "        OPTIONAL { " +
-            "            ?ee dbnary:describes ?nee . " +
-            "            ?nee rdf:type ontolex:LexicalEntry . " +
-            "            ?nee dbnary:partOfSpeech ?pos . " +
-            "        } " +
-            "        OPTIONAL { " +
-            "            ?ee dbnary:describes ?cee . " +
-            "            ?cee dbnary:describes ?nee . " +
-            "            ?nee rdf:type ontolex:LexicalEntry . " +
-            "            ?nee dbnary:partOfSpeech ?pos . " +
-            "        } " +
-            "        OPTIONAL { " +
-            "            ?ee ontolex:sense ?sense . " +
-            "            ?sense skos:definition ?val . " +
-            "            ?val rdf:value ?def . " +
-            "        } " +
-            "        OPTIONAL { " +
-            "            ?ee dbnary:describes ?nee . " +
-            "            ?nee rdf:type ontolex:LexicalEntry . " +
-            "            ?nee ontolex:sense ?sense . " +
-            "            ?sense skos:definition ?val . " +
-            "            ?val rdf:value ?def . " +
-            "        } " +
-            "        OPTIONAL { " +
-            "            ?ee dbnary:describes ?cee . " +
-            "            ?cee dbnary:describes ?nee . " +
-            "            ?nee rdf:type ontolex:LexicalEntry . " +
-            "            ?nee skos:sense ?sense . " +
-            "            ?sense skos:definition ?val . " +
-            "            ?val rdf:value ?def . " +
-            "        } " +
-            "    } " +
-            "} ";
-        return query;
-    };
-
-    //(related|equivalent){0,5}
-    //DEFINE QUERIES TO PLOT GRAPH          
-    module.ancestorQuery = function(iri, queryDepth) {
-        var query = "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> ";
-        if (queryDepth === 1) {
-            query +=
-                "SELECT DISTINCT ?ancestor1 ?ancestor2 " +
-                "{ " +
-                "   <" + iri + "> dbetym:etymologicallyRelatedTo{0,5} ?ancestor1 . " +
-                "   OPTIONAL {?eq dbetym:etymologicallyEquivalentTo ?ancestor1 . " +
-                "   ?eq dbetym:etymologicallyRelatedTo* ?ancestor2 .} " +
+        var disambiguationQuery = function(lemma) {
+            var encodedWord = lemma.replace(/'/g, "\\\\'").replace("·", "%C2%B7");
+            var query =
+                "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> " +
+                "PREFIX dbnary: <http://kaiko.getalp.org/dbnary#> " +
+                "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
+                "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
+                "SELECT DISTINCT ?iri (group_concat(distinct ?ee ; separator=\",\") as ?et) " +
+                "WHERE { " +
+                "    ?iri rdfs:label ?label . ?label bif:contains \"\'" + encodedWord + "\'\" . " +
+                //exclude entries that contain the searched word but include other words
+                //(e.g.: search="door" label="doorbell", exclude "doorbell")
+                "    FILTER REGEX(?label, \"^" + encodedWord + "$\", 'i') . " +
+                "    ?iri rdf:type dbetym:EtymologyEntry . " +
+                "    OPTIONAL { " +
+                "        ?iri dbnary:describes  ?ee . " +
+                "        ?ee rdf:type dbetym:EtymologyEntry . " +
+                "    } " +
                 "} ";
-        } else if (queryDepth === 2) {
-            query +=
-                "SELECT DISTINCT ?ancestor1 " +
-                "{ " +
-                "   <" + iri + "> dbetym:etymologicallyRelatedTo{0,5} ?ancestor1 . " +
+
+            return query;
+        };
+
+        //DEFINE QUERY TO GET LINKS, POS AND GLOSS           
+        var lemmaQuery = function(iri) {
+            var query =
+                "PREFIX dbnary: <http://kaiko.getalp.org/dbnary#> " +
+                "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
+                "PREFIX lexinfo: <http://www.lexinfo.net/ontology/2.0/lexinfo#> " +
+                "PREFIX skos: <http://www.w3.org/2004/02/skos/core#> " +
+                "PREFIX ontolex: <http://www.w3.org/ns/lemon/ontolex#> " +
+                "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
+                "SELECT DISTINCT ?ee ?pos (group_concat(distinct ?def ; separator=\";;;;\") as ?gloss) (group_concat(distinct ?also ; separator=\",\") as ?links) " +
+                "WHERE { " +
+                "    <" + iri.replace(/__ee_[0-9]+_/g, "__ee_") + "> rdfs:seeAlso ?also . " +
+                "    OPTIONAL { " +
+                "        <" + iri + "> dbnary:describes ?ee . " +
+                "        OPTIONAL { " +
+                "            ?ee rdf:type ontolex:LexicalEntry . " +
+                "            ?ee dbnary:partOfSpeech ?pos . " +
+                "        } " +
+                "        OPTIONAL { " +
+                "            ?ee dbnary:describes ?nee . " +
+                "            ?nee rdf:type ontolex:LexicalEntry . " +
+                "            ?nee dbnary:partOfSpeech ?pos . " +
+                "        } " +
+                "        OPTIONAL { " +
+                "            ?ee dbnary:describes ?cee . " +
+                "            ?cee dbnary:describes ?nee . " +
+                "            ?nee rdf:type ontolex:LexicalEntry . " +
+                "            ?nee dbnary:partOfSpeech ?pos . " +
+                "        } " +
+                "        OPTIONAL { " +
+                "            ?ee ontolex:sense ?sense . " +
+                "            ?sense skos:definition ?val . " +
+                "            ?val rdf:value ?def . " +
+                "        } " +
+                "        OPTIONAL { " +
+                "            ?ee dbnary:describes ?nee . " +
+                "            ?nee rdf:type ontolex:LexicalEntry . " +
+                "            ?nee ontolex:sense ?sense . " +
+                "            ?sense skos:definition ?val . " +
+                "            ?val rdf:value ?def . " +
+                "        } " +
+                "        OPTIONAL { " +
+                "            ?ee dbnary:describes ?cee . " +
+                "            ?cee dbnary:describes ?nee . " +
+                "            ?nee rdf:type ontolex:LexicalEntry . " +
+                "            ?nee skos:sense ?sense . " +
+                "            ?sense skos:definition ?val . " +
+                "            ?val rdf:value ?def . " +
+                "        } " +
+                "    } " +
                 "} ";
-        }
-        return query;
-    };
+            return query;
+        };
 
-    module.descendantQuery = function(iri) {
-        var query =
-            "SELECT DISTINCT ?descendant1 " + // ?descendant2",
-            "{ " +
-            "   ?descendant1 dbetym:etymologicallyRelatedTo{0,2} <" + iri + "> . " +
-            //   "   OPTIONAL {?eq dbetym:etymologicallyEquivalentTo ?descendant1 . " +
-            //  "   ?descendant2 dbetym:etymologicallyRelatedTo* ?eq .} " +
-            "} ";
-        return query;
-    };
+        //(related|equivalent){0,5}
+        //DEFINE QUERIES TO PLOT GRAPH          
+        var ancestorQuery = function(iri, queryDepth) {
+            var query = "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> ";
+            if (queryDepth === 1) {
+                query +=
+                    "SELECT DISTINCT ?ancestor1 ?ancestor2 " +
+                    "{ " +
+                    "   <" + iri + "> dbetym:etymologicallyRelatedTo{0,5} ?ancestor1 . " +
+                    "   OPTIONAL {?eq dbetym:etymologicallyEquivalentTo ?ancestor1 . " +
+                    "   ?eq dbetym:etymologicallyRelatedTo* ?ancestor2 .} " +
+                    "} ";
+            } else if (queryDepth === 2) {
+                query +=
+                    "SELECT DISTINCT ?ancestor1 " +
+                    "{ " +
+                    "   <" + iri + "> dbetym:etymologicallyRelatedTo{0,5} ?ancestor1 . " +
+                    "} ";
+            }
+            return query;
+        };
 
-    module.propertyQuery = function(iri) {
-        var query =
-            "SELECT DISTINCT ?s ?rel ?eq ?der " +
-            "{           " +
-            "   VALUES ?rel " +
-            "   {           " +
-            "       <" + iri + "> " +
-            "   } " +
-            "   ?s dbetym:etymologicallyRelatedTo ?rel . " +
-            "   OPTIONAL { ?rel dbetym:etymologicallyEquivalentTo{0,6} ?eq . } " +
-            "   OPTIONAL { ?s dbetym:etymologicallyDerivesFrom ?der . } " +
-            //  "   FILTER NOT EXISTS { ?rel dbetym:etymologicallyDerivesFrom ?der2 . } "+
-            "}";
-        return query;
-    };
+        var descendantQuery = function(iri) {
+            var query =
+                "SELECT DISTINCT ?descendant1 " + // ?descendant2",
+                "{ " +
+                "   ?descendant1 dbetym:etymologicallyRelatedTo{0,2} <" + iri + "> . " +
+                //   "   OPTIONAL {?eq dbetym:etymologicallyEquivalentTo ?descendant1 . " +
+                //  "   ?descendant2 dbetym:etymologicallyRelatedTo* ?eq .} " +
+                "} ";
+            return query;
+        };
 
-    module.unionQuery = function(iriArray, queryFunction) {
-        var query =
-            "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> " +
-            "SELECT * WHERE {{ " +
-            iriArray.map(function(iri) { return queryFunction(iri); }).join("} UNION {") +
-            "}}";
-        return query;
+        var propertyQuery = function(iri) {
+            var query =
+                "SELECT DISTINCT ?s ?rel ?eq ?der " +
+                "{           " +
+                "   VALUES ?rel " +
+                "   {           " +
+                "       <" + iri + "> " +
+                "   } " +
+                "   ?s dbetym:etymologicallyRelatedTo ?rel . " +
+                "   OPTIONAL { ?rel dbetym:etymologicallyEquivalentTo{0,6} ?eq . } " +
+                "   OPTIONAL { ?s dbetym:etymologicallyDerivesFrom ?der . } " +
+                //  "   FILTER NOT EXISTS { ?rel dbetym:etymologicallyDerivesFrom ?der2 . } "+
+                "}";
+            return query;
+        };
+
+        var unionQuery = function(iriArray, queryFunction) {
+            var query =
+                "PREFIX dbetym: <http://etytree-virtuoso.wmflabs.org/dbnaryetymology#> " +
+                "SELECT * WHERE {{ " +
+                iriArray.map(function(iri) { return queryFunction(iri); }).join("} UNION {") +
+                "}}";
+            return query;
+        };
+
+        this.ENDPOINT = ENDPOINT;
+        this.getXMLHttpRequest = getXMLHttpRequest;
+        this.slicedQuery = slicedQuery;
+        this.disambiguationQuery = disambiguationQuery;
+        this.lemmaQuery = lemmaQuery;
+        this.ancestorQuery = ancestorQuery;
+        this.descendantQuery = descendantQuery;
+        this.propertyQuery = propertyQuery;
+        this.unionQuery = unionQuery;
+
+        etyBase[moduleName] = this;
     };
 
     return module;

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -1,7 +1,7 @@
 /*globals
     Rx, XMLHttpRequest, console, d3, MESSAGE, LOAD
 */
-var SPARQL = (function(module) {
+var DB = (function(module) {
 
     module.ENDPOINT = "https://etytree-virtuoso.wmflabs.org/sparql";
 
@@ -32,7 +32,7 @@ var SPARQL = (function(module) {
         var i, j, tmpArray, url, sources = [];
         for (i = 0, j = myArray.length; i < j; i += chunk) {
             tmpArray = myArray.slice(i, i + chunk);
-            //console.log(SPARQL.unionQuery(tmpArray, query));                   
+            //console.log(DB.unionQuery(tmpArray, query));                   
             url = this.ENDPOINT + "?query=" + encodeURIComponent(this.unionQuery(tmpArray, queryFunction));
             if (LOAD.settings.debug) {
                 console.log(url);
@@ -186,4 +186,4 @@ var SPARQL = (function(module) {
     };
 
     return module;
-})(SPARQL || {});
+})(DB || {});

--- a/resources/js/sparql.js
+++ b/resources/js/sparql.js
@@ -188,80 +188,6 @@ var DB = (function(module) {
             return query;
         };
 
-        var init = function() {
-
-            d3.select("#helpPopup").html(etyBase.LOAD.HELP.intro);
-
-            var div = d3.select("body").append("div")
-                .attr("data-role", "popup")
-                .attr("data-dismissible", "true")
-                .attr("id", "tooltipPopup")
-                .style("display", "none")
-                .attr("class", "ui-content tooltipDiv");
-
-            $(window).click(function() {
-                d3.select("#tooltipPopup")
-                    .style("display", "none");
-            });
-
-            $('#tooltipPopup').click(function(event) {
-                event.stopPropagation();
-            });
-
-            $('#tags').on("keypress click", function(e) {
-                var tag = this;
-                if (e.which === 13 || e.type === 'click') {
-                    var lemma = $(tag).val(); //.replace("/", "!slash!");
-
-                    if (lemma) {
-                        if (etyBase.LOAD.settings.debug) {
-                            console.log("searching lemma in database");
-                        }
-                        var width = window.innerWidth,
-                            height = $(document).height() - $('#header').height();
-                        var url = etyBase.DB.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
-                        if (etyBase.LOAD.settings.debug) {
-                            console.log(url);
-                        }
-
-                        const source = etyBase.DB.getXMLHttpRequest(url);
-                        source.subscribe(
-                            function(response) {
-                                if (response !== undefined && response !== null) {
-                                    d3.select("#tree-overlay").remove();
-                                    d3.select("#tooltipPopup").style("display", "none");
-
-                                    var g = etyBase.GRAPH.buildDisambiguationDAGRE(response);
-                                    if (null === g) {
-                                        d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
-                                    } else {
-                                        if (Object.keys(g.nodess).length > 1) {
-                                            d3.select("#helpPopup").html(etyBase.LOAD.HELP.disambiguation);
-                                            d3.select("#message").style("display", "inline").html("There are multiple words in the database. <br>Which word are you interested in?");
-                                            var inner = etyBase.GRAPH.renderGraph(g, width, height);
-                                            etyBase.GRAPH.appendLanguageTagTextAndTooltip(inner, g);
-                                            etyBase.GRAPH.appendDefinitionTooltipOrDrawDAGRE(inner, g, width, height);
-
-                                            d3.selectAll(".edgePath").remove();
-                                        } else {
-                                            var iri = Object.keys(g.nodess)[0];
-                                            etyBase.GRAPH.drawDAGRE(iri, 2, width, height);
-                                        }
-                                    }
-                                }
-                            },
-                            function(error) {
-                                console.error(error);
-                                d3.select("#message").style("display", "inline").html(etyBase.LOAD.MESSAGE.notAvailable);
-                            },
-                            () => console.log('done disambiguation'));
-                    }
-                }
-            });
-
-
-        };
-
         this.ENDPOINT = ENDPOINT;
         this.getXMLHttpRequest = getXMLHttpRequest;
         this.slicedQuery = slicedQuery;
@@ -271,8 +197,6 @@ var DB = (function(module) {
         this.descendantQuery = descendantQuery;
         this.propertyQuery = propertyQuery;
         this.unionQuery = unionQuery;
-        this.init = init;
-
         etyBase[moduleName] = this;
     };
 


### PR DESCRIPTION
This is a big set of changes, and it requires a little explanation. But there are a lot of advantages to what we have changed here, including the ease of swapping out different visualization systems like dagre -> visjs, etc. This all applies to issues #24 and #15 

## Changes!

### 1. Module Changes

The files [dagre.js](https://github.com/esterpantaleo/etymology/blob/master/resources/js/dagre.js), [load.js](https://github.com/esterpantaleo/etymology/blob/master/resources/js/load.js), and [sparql.js](https://github.com/esterpantaleo/etymology/blob/master/resources/js/sparql.js) are all wrapped in a special function that "exports" them as modules:
`````
var DB = (function(module) {
    ....
    return module;
})(DB || {});
`````
The module names are DB for sparql.js, GRAPH for dagre.js, and LOAD for load.js. These are so we could switch out sparql or dagre if we needed to without having to change the names of any function calls in the other files.

Another positive benefit to this is that it allows us to load the modules asynchronously, and now the page loads twice as fast as it did before (initial page load, not data load from a query)

### 2. Bindings

Inside those module wrappers, there is a "binding" wrapper around all the rest of the functions of that file. Here's the example from the LOAD module:
`````
var LOAD = (function(module) {

    module.bindModule = function(base, moduleName) {
        var etyBase = base;

        ...

        this.HELP = HELP;
        this.MESSAGE = MESSAGE;
        this.classes = {
            GraphNode: GraphNode,
            Node: Node
        };
        this.init = init;

        etyBase[moduleName] = this;
    };

    return module;

})(LOAD || {});
`````

This allows us to set the EtyTree object as the base for each module so that all other modules can always be called by calling `etyBase.MODULE.FUNCTION()` such as `etyBase.DB.lemmaQuery()`. This is particularly helpful because now that means that any change we make to the data from within the modules should still stay linked properly. It also helps ensure that things stay separated so we can always keep the modules working in the future.

### 3. EtyTree Command Center

The [etytree.js](https://github.com/esterpantaleo/etymology/blob/master/resources/js/etytree.js) file now contains much less code. The functions that start up the tree have been moved to other files as `init()` functions, but they get called from etytree.js. Now etytree.js is the **command center** -- code that goes there is mainly to get basic settings in place and to coordinate between modules. Everything else can happen elsewhere.

EtyTree is now an object with a `create()` and an `init()` function. I'm sure that this could have been done with ES6 classes, but it was faster for me to do it this way for now. It can be changed to a class later.

The `create()` function binds the modules to the EtyTree object and adds config info. This is now where the ENDPOINT and debug info is stored.

The `init()` function runs the `init()` functions of any modules that have one. It also adds the `etyBase.tree`, which is where some data can be stored in the future. This is key because it now allows us to story information as a property of the EtyTree instead of passing it around the functions. This is where things like "inner", "g", "LangMap", and data from query responses should be stored so that they can be accessed by functions in all modules. **THIS IS THE KEY TO WHY WE ARE USING MODULES** -- as of now, only the LangMap gets assigned as a property of `etyBase.tree`, but we can start abstracting other things out of that.

The variable `var ety` is created as an instance of `EtyTree` and initialized after document load, making sure that all dependencies are loaded before anything runs.

## Working With Modules

Now that we have this module system, it is critical that we continue to use the same format. It takes a little getting used to, but it will keep the etytree from falling apart.

It is very simple:
- Always make sure new functions for modules are declared INSIDE the `module.bindModule` function.
- Add the new functions to the module by creating a `this.FUNCTIONNAME = FUNCTIONNAME;` line at the bottom of the `module.bindModule` function but above `etyBase[moduleName] = this;`
- Always call functions with the structure `etyBase.MODULE.etc` so that you are sure to always access the correct data.

## That's it!

Please take a look at these changes and make sure it all makes sense. Let me know if you have any questions.

### Follow Up?

After this is merged, this opens us up to:
1. More easily switch out dagre for visjs
2. Add remove some of the "global" information from function arguments and set them as EtyTree properties
3. Test different functions by only switching the reference that is assigned to the module and not having to rewrite the function call in multiple places in multiple files. ( `this.render = render1` => `this.render = render2`, but everywhere else you would just call `etyBase.GRAPH.render()` ).