### PR TITLE
Set data independent of graph drawing

### DIFF
--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -216,6 +216,7 @@ var GRAPH = (function(module) {
                                         etyBase.DB.slicedQuery(allArray, etyBase.DB.propertyQuery, 3)
                                             .subscribe(
                                                 propertyResponse => {
+                                                    setData(ancestorArray, ancestorResponse, propertyResponse);
                                                     var g = parseEtymologyNodes(ancestorArray, ancestorResponse, propertyResponse);
 
                                                     if (Object.keys(g.nodess).length === 0) {
@@ -245,6 +246,7 @@ var GRAPH = (function(module) {
                             etyBase.DB.slicedQuery(ancestorArray, etyBase.DB.propertyQuery, 3)
                                 .subscribe(
                                     propertyResponse => {
+                                        setData(ancestorArray, ancestorResponse, propertyResponse);
                                         var g = parseEtymologyNodes(ancestorArray, ancestorResponse, propertyResponse);
 
                                         if (Object.keys(g.nodess).length === 0) {
@@ -273,14 +275,18 @@ var GRAPH = (function(module) {
                     });
         };
 
-        var parseEtymologyNodes = function(ancestors, ancestorResponse, propertyResponse) {
-            var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
-            g.nodess = {};
-
-            var allArray = propertyResponse.reduce((all, a) => {
+        var setData = function(ancestors, ancestorResponse, propertyResponse) {
+            etyBase.tree.data = propertyResponse.reduce((all, a) => {
                 all = all.concat(JSON.parse(a).results.bindings);
                 return all;
             }, []);
+        };
+
+        var parseEtymologyNodes = function(ancestors, ancestorResponse, propertyResponse) {
+            var allArray = etyBase.tree.data;
+            var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+            g.nodess = {};
+
             if (allArray.length < 2) {
                 return g;
             } else {

--- a/resources/js/dagre.js
+++ b/resources/js/dagre.js
@@ -1,85 +1,86 @@
 /*globals
-    $, d3, console, dagreD3, Rx, window, document
+    $, d3, console, dagreD3, Rx, window, document, URLSearchParams
 */
-/*jshint loopfunc: true, shadow: true */ // Consider removing this and fixing these
+/*jshint loopfunc: true, shadow: true, latedef: false */ // Consider removing this and fixing these
 var GRAPH = (function(module) {
 
     module.bindModule = function(base, moduleName) {
         var etyBase = base;
 
-	var serverError = function(error) {
-	    console.log(error);
+        var serverError = function(error) {
+            console.log(error);
 
-	    $('#message')
+            $('#message')
                 .css('display', 'inline')
                 .html(etyBase.LOAD.MESSAGE.serverError);
-	}
+        };
 
-	var notAvailable = function(error) {
-	    console.error(error);
-            
-	    $('#tree-overlay')
-		.remove();
-            d3.select("#tooltipPopup")
-		.style("display", "none");
-            $('#message')
-		.css('display', 'inline')
-		.html(etyBase.LOAD.MESSAGE.notAvailable);
-	}
+        var notAvailable = function(error) {
+            console.error(error);
 
-	var constructDisambiguationGraph = function(lemma) {
-	    //clean screen
-	    $('#tree-overlay')
+            $('#tree-overlay')
                 .remove();
             d3.select("#tooltipPopup")
                 .style("display", "none");
-	    
-	    //query database
-	    var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
+            $('#message')
+                .css('display', 'inline')
+                .html(etyBase.LOAD.MESSAGE.notAvailable);
+        };
+
+        var constructDisambiguationGraph = function(lemma) {
+            //clean screen
+            $('#tree-overlay')
+                .remove();
+            d3.select("#tooltipPopup")
+                .style("display", "none");
+
+            //query database
+            var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(etyBase.DB.disambiguationQuery(lemma));
             if (etyBase.config.debug) {
                 console.log("disambiguation query = " + url);
             }
             etyBase.DB.getXMLHttpRequest(url).subscribe(
                 response => {
-		    var g = parseDisambiguationNodes(response);
+                    var g = parseDisambiguationNodes(response);
                     if (Object.keys(g.nodess).length === 0) {
                         $('#message')
                             .css('display', 'inline')
                             .html(etyBase.LOAD.MESSAGE.notAvailable);
                     } else if (Object.keys(g.nodess).length === 1) {
-			var iri = Object.keys(g.nodess)[0];
+                        var iri = Object.keys(g.nodess)[0];
                         constructEtymologyGraph(iri);
-		    } else {
+                    } else {
                         $('#helpPopup')
                             .html(etyBase.LOAD.HELP.disambiguation);
                         $('#message')
                             .css('display', 'inline')
                             .html(etyBase.LOAD.MESSAGE.disambiguation);
-                        renderGraph(g).selectAll("g.node")
+                        setGraph(g);
+                        renderGraph().selectAll("g.node")
                             .on("click", function(d) {
                                 var iri = g.node(d).iri;
-				
+
                                 constructEtymologyGraph(iri);
-                            })
-                    } 
-		},
-		error => { 
-		    $('#message')
-			.css('display', 'inline')
-			.html("Server error. " + error); 
-		},
-                () => { 
-		    if (etyBase.config.debug) {
-			console.log('done disambiguation');
-		    }
-		});
-	};
-		
+                            });
+                    }
+                },
+                error => {
+                    $('#message')
+                        .css('display', 'inline')
+                        .html("Server error. " + error);
+                },
+                () => {
+                    if (etyBase.config.debug) {
+                        console.log('done disambiguation');
+                    }
+                });
+        };
+
         var parseDisambiguationNodes = function(response) {
-	    var g = new dagreD3.graphlib.Graph().setGraph({});
-	    g.nodess = {};
-	    var disambiguationArray = JSON.parse(response).results.bindings;
-	    
+            var g = new dagreD3.graphlib.Graph().setGraph({});
+            g.nodess = {};
+            var disambiguationArray = JSON.parse(response).results.bindings;
+
             //define nodes 
             disambiguationArray.forEach(function(n) {
                 n.et.value.split(",")
@@ -102,153 +103,157 @@ var GRAPH = (function(module) {
                 m = n;
             }
 
-	    if (etyBase.config.debug) {
+            if (etyBase.config.debug) {
                 console.log(g.nodess);
             }
             return g;
         };
 
-	var parseAncestors = function(response) {
-	    var ancestorArray = response.reduce((all, a) => {
-		return all.concat(JSON.parse(a).results.bindings);
-	    }, [])
+        var parseAncestors = function(response) {
+            var ancestorArray = response.reduce((all, a) => {
+                    return all.concat(JSON.parse(a).results.bindings);
+                }, [])
                 .reduce((ancestors, a) => {
                     ancestors.push(a.ancestor1.value);
                     if (a.der1.value === "0" && undefined !== a.ancestor2 && lemmaNotStartsOrEndsWithDash(a.ancestor1.value)) {
                         ancestors.push(a.ancestor2.value);
                         if (a.der2.value === "0" && undefined !== a.ancestor3 && lemmaNotStartsOrEndsWithDash(a.ancestor2.value)) {
-                            ancestors.push(a.ancestor3.value); 
-			    if (a.der3.value === "0" && undefined !== a.ancestor4 && lemmaNotStartsOrEndsWithDash(a.ancestor3.value)) {
-				ancestors.push(a.ancestor4.value);
-				if (a.der4.value === "0" && undefined !== a.ancestor5 && lemmaNotStartsOrEndsWithDash(a.ancestor4.value)) {
-				    ancestors.push(a.ancestor5.value);
-				}
-			    }
+                            ancestors.push(a.ancestor3.value);
+                            if (a.der3.value === "0" && undefined !== a.ancestor4 && lemmaNotStartsOrEndsWithDash(a.ancestor3.value)) {
+                                ancestors.push(a.ancestor4.value);
+                                if (a.der4.value === "0" && undefined !== a.ancestor5 && lemmaNotStartsOrEndsWithDash(a.ancestor4.value)) {
+                                    ancestors.push(a.ancestor5.value);
+                                }
+                            }
                         }
                     }
                     return ancestors;
                 }, []).filter(etyBase.helpers.onlyUnique);
-	    console.log("ancestors");
-	    console.log(ancestorArray);
-	    return ancestorArray;
+            console.log("ancestors");
+            console.log(ancestorArray);
+            return ancestorArray;
         };
-	
-	var parseDescendants = function(ancestorArray, response) {
-	    var descendantArray = response
-		.reduce(
-		    (descendants, d) => {
-			descendants = descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
-			return descendants;
-		    }, []).filter(etyBase.helpers.onlyUnique);
-	    console.log("descendants");
-	    console.log(descendantArray);
-	    return ancestorArray.concat(descendantArray).filter(etyBase.helpers.onlyUnique);
-	};
 
-	//if the searched word is derived from 2 or more words, return false
-	//i.e. do not search for descendants
-	//In this case the searched word is a compound word
-	//we are not interested in descendants of the words that make up the searched word
-	var doFindDescendants = function(response) {
-	    var firstAncestorArray = response.reduce((all, a) => {
-		return all.concat(JSON.parse(a).results.bindings);
-	    }, [])
-		.reduce((ancestors, a) => {
-		    if (a.der1.value === "1") {
-			ancestors.push(a.ancestor1.value);
-		    }
-		    return ancestors;
-		}, []).filter(etyBase.helpers.onlyUnique);
-	    if (firstAncestorArray.length > 1)
-		return false;
-	    else
-		return true;
-	};
+        var parseDescendants = function(ancestorArray, response) {
+            var descendantArray = response
+                .reduce(
+                    (descendants, d) => {
+                        descendants = descendants.concat(JSON.parse(d).results.bindings.map(function(t) { return t.descendant1.value; }));
+                        return descendants;
+                    }, []).filter(etyBase.helpers.onlyUnique);
+            console.log("descendants");
+            console.log(descendantArray);
+            return ancestorArray.concat(descendantArray).filter(etyBase.helpers.onlyUnique);
+        };
 
-	var lemmaNotStartsOrEndsWithDash = function(iri) {
-	    tmp = iri.replace("http://etytree-virtuoso.wmflabs.org/dbnary/eng/", "")
-	    .split("/");
-	    if (tmp.length > 1) {
-		label = tmp[1];
-	    } else {
-		label = tmp[0];
-	    }
-	    label = label.replace(/__ee_[0-9]+_/g, "")
-                    .replace("__ee_", "");
-	    
-	    if (label.startsWith("-") || label.startsWith("_-") || label.endsWith("-")){
-		return false;
-	    } else {
-		return true;
-	    }
-	};
-	    
+        //if the searched word is derived from 2 or more words, return false
+        //i.e. do not search for descendants
+        //In this case the searched word is a compound word
+        //we are not interested in descendants of the words that make up the searched word
+        var doFindDescendants = function(response) {
+            var firstAncestorArray = response.reduce((all, a) => {
+                    return all.concat(JSON.parse(a).results.bindings);
+                }, [])
+                .reduce((ancestors, a) => {
+                    if (a.der1.value === "1") {
+                        ancestors.push(a.ancestor1.value);
+                    }
+                    return ancestors;
+                }, []).filter(etyBase.helpers.onlyUnique);
+            if (firstAncestorArray.length > 1)
+                return false;
+            else
+                return true;
+        };
+
+        var lemmaNotStartsOrEndsWithDash = function(iri) {
+        	var tmp,
+        		label;
+            tmp = iri.replace("http://etytree-virtuoso.wmflabs.org/dbnary/eng/", "")
+                .split("/");
+            if (tmp.length > 1) {
+                label = tmp[1];
+            } else {
+                label = tmp[0];
+            }
+            label = label.replace(/__ee_[0-9]+_/g, "")
+                .replace("__ee_", "");
+
+            if (label.startsWith("-") || label.startsWith("_-") || label.endsWith("-")) {
+                return false;
+            } else {
+                return true;
+            }
+        };
+
         var constructEtymologyGraph = function(iri) {
             $('#message')
-		.css('display', 'inline')
-		.html(etyBase.LOAD.MESSAGE.loadingMore);
+                .css('display', 'inline')
+                .html(etyBase.LOAD.MESSAGE.loadingMore);
             d3.select("#tooltipPopup")
-		.attr("display", "none");
+                .attr("display", "none");
             $('#tree-overlay')
-		.remove();
-	    d3.select("#tooltipPopup")
+                .remove();
+            d3.select("#tooltipPopup")
                 .attr("display", "none");
 
-	    const params = new URLSearchParams();
-	    params.set("format", "application/sparql-results+json");
-	    var url = etyBase.config.urls.ENDPOINT + "?" + params;
-	    
-	    etyBase.DB.ancestorQuery(iri, 5)
-		.subscribe(
-		    ancestorResponse => {
-			var ancestorArray = parseAncestors(ancestorResponse);
-			ancestorArray.push(iri);
-			var filteredAncestorArray = ancestorArray.filter(function(element) { return lemmaNotStartsOrEndsWithDash(element); });
-			
-			if (doFindDescendants(ancestorResponse)) {
-			    etyBase.DB.slicedQuery(filteredAncestorArray, etyBase.DB.descendantQuery, 8)
-				.subscribe( 
-				    descendantResponse => { 
-					var allArray = parseDescendants(ancestorArray, descendantResponse);
-					etyBase.DB.slicedQuery(allArray, etyBase.DB.propertyQuery, 3)
-					    .subscribe(
-						propertyResponse => {
-						    var g = parseEtymologyNodes(ancestorArray, ancestorResponse, propertyResponse);
-						    
-						    if (Object.keys(g.nodess).length === 0) {
-							$('#message')
-							    .css('display', 'inline')
-							    .html(etyBase.LOAD.MESSAGE.noEtymology);
-						    } else {
-							$('#helpPopup').html(etyBase.LOAD.HELP.dagre);
-							renderGraph(g);
-						    }
-						},
-						error => serverError(error),
-						() => {
-						    if (etyBase.config.debug) {
-							console.log('done property query');
-						    }
-						});
-				    },
-				    error => serverError(error),
-				    () => {
-					if (etyBase.config.debug) {
-					    console.log('done descendants query');
-					}
-				    });
-			} else {
-			    etyBase.DB.slicedQuery(ancestorArray, etyBase.DB.propertyQuery, 3)
+            const params = new URLSearchParams();
+            params.set("format", "application/sparql-results+json");
+            var url = etyBase.config.urls.ENDPOINT + "?" + params;
+
+            etyBase.DB.ancestorQuery(iri, 5)
+                .subscribe(
+                    ancestorResponse => {
+                        var ancestorArray = parseAncestors(ancestorResponse);
+                        ancestorArray.push(iri);
+                        var filteredAncestorArray = ancestorArray.filter(function(element) { return lemmaNotStartsOrEndsWithDash(element); });
+
+                        if (doFindDescendants(ancestorResponse)) {
+                            etyBase.DB.slicedQuery(filteredAncestorArray, etyBase.DB.descendantQuery, 8)
                                 .subscribe(
-				    propertyResponse => {
+                                    descendantResponse => {
+                                        var allArray = parseDescendants(ancestorArray, descendantResponse);
+                                        etyBase.DB.slicedQuery(allArray, etyBase.DB.propertyQuery, 3)
+                                            .subscribe(
+                                                propertyResponse => {
+                                                    var g = parseEtymologyNodes(ancestorArray, ancestorResponse, propertyResponse);
+
+                                                    if (Object.keys(g.nodess).length === 0) {
+                                                        $('#message')
+                                                            .css('display', 'inline')
+                                                            .html(etyBase.LOAD.MESSAGE.noEtymology);
+                                                    } else {
+                                                        $('#helpPopup').html(etyBase.LOAD.HELP.dagre);
+                                                        setGraph(g);
+                                                        renderGraph(g);
+                                                    }
+                                                },
+                                                error => serverError(error),
+                                                () => {
+                                                    if (etyBase.config.debug) {
+                                                        console.log('done property query');
+                                                    }
+                                                });
+                                    },
+                                    error => serverError(error),
+                                    () => {
+                                        if (etyBase.config.debug) {
+                                            console.log('done descendants query');
+                                        }
+                                    });
+                        } else {
+                            etyBase.DB.slicedQuery(ancestorArray, etyBase.DB.propertyQuery, 3)
+                                .subscribe(
+                                    propertyResponse => {
                                         var g = parseEtymologyNodes(ancestorArray, ancestorResponse, propertyResponse);
-					
+
                                         if (Object.keys(g.nodess).length === 0) {
                                             $('#message')
                                                 .css('display', 'inline')
                                                 .html(etyBase.LOAD.MESSAGE.noEtymology);
                                         } else {
                                             $('#helpPopup').html(etyBase.LOAD.HELP.dagre);
+                                            setGraph(g);
                                             renderGraph(g);
                                         }
                                     },
@@ -258,133 +263,133 @@ var GRAPH = (function(module) {
                                             console.log('done property query');
                                         }
                                     });
-			}
+                        }
                     },
                     error => serverError(error),
                     () => {
-			if (etyBase.config.debug) {
-			    console.log('done ancestor query');
-			}
-		    });
-	};
-	
-        var parseEtymologyNodes = function(ancestors, ancestorResponse, propertyResponse) {
-	    var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
-	    g.nodess = {};
+                        if (etyBase.config.debug) {
+                            console.log('done ancestor query');
+                        }
+                    });
+        };
 
-	    var allArray = propertyResponse.reduce((all, a) => {
-		all = all.concat(JSON.parse(a).results.bindings);
+        var parseEtymologyNodes = function(ancestors, ancestorResponse, propertyResponse) {
+            var g = new dagreD3.graphlib.Graph().setGraph({ rankdir: 'LR' });
+            g.nodess = {};
+
+            var allArray = propertyResponse.reduce((all, a) => {
+                all = all.concat(JSON.parse(a).results.bindings);
                 return all;
             }, []);
             if (allArray.length < 2) {
-		return g;
-	    } else {
-		console.log("allArray");
-		console.log(allArray);
-		//CONSTRUCTING NODES
-		allArray.forEach(function(element) {
-		    //save all nodes        
-		    //define isAncestor
-		    if (undefined !== element.s && undefined === g.nodess[element.s.value]) {
-			var label = (undefined === element.sLabel) ? undefined : element.sLabel.value; 
-			g.nodess[element.s.value] = new etyBase.LOAD.classes.Node(element.s.value, label);
-		    }
-		    if (undefined !== element.rel) {
-			if (undefined === g.nodess[element.rel.value]) {
-			    var label = (undefined === element.relLabel) ? undefined : element.relLabel.value;
-			    g.nodess[element.rel.value] = new etyBase.LOAD.classes.Node(element.rel.value, label);
-			}
-			if (ancestors.indexOf(element.rel.value) > -1) {
-			    g.nodess[element.rel.value].isAncestor = true;
-			}
-		    }
-		    if (undefined !== element.rel && undefined !== element.eq) {
-			if (undefined === g.nodess[element.eq.value]) {
-			    var label = (undefined === element.eqLabel) ? undefined : element.eqLabel.value;
-			    g.nodess[element.eq.value] = new etyBase.LOAD.classes.Node(element.eq.value, label);
-			}
-			//push to eqIri
-			if (element.rel.value !== element.eq.value) {
-			    if (g.nodess[element.rel.value].eqIri.indexOf(element.eq.value) == -1) {
-				g.nodess[element.rel.value].eqIri.push(element.eq.value);
-			    }
-			    if (g.nodess[element.eq.value].eqIri.indexOf(element.rel.value) == -1) {
-				g.nodess[element.eq.value].eqIri.push(element.rel.value);
-			    }
-			}
-		    }
-		});
-
-		//CONSTRUCTING GRAPHNODES
-		//a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
-		//or that refer to the same word - also called here identical Nodes 
-		//(e.g.: if only ee_word and ee_n_word with n an integer belong to
-		//the set of ancestors and descendants           
-		//then merge them into one graphNode) 
-		//the final graph will use these super nodes (graphNodes)  
-		g.graphNodes = {};
-		var counter = 0; //counts how many graphNodes have been created so far
-		for (var n in g.nodess) {
-                    if (g.nodess[n].ety === 0) {
-			var iso = g.nodess[n].iso;
-			var label = g.nodess[n].label;
-			var tmp = [];
-			for (var m in g.nodess) {
-                            if (undefined !== g.nodess[m]) {
-				if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
-                                    if (g.nodess[m].ety > 0) {
-					tmp.push(m);
-                                    }
-				}
-                            }
-			}
-			tmp = tmp.filter(etyBase.helpers.onlyUnique);
-			//if only ee_word and ee_n_word with n an integer belong to
-			//the set of ancestors and descendants
-			//then merge them in one graphNode
-			if (tmp.length === 1) {
-                    //        var gg = new etyBase.LOAD.classes.GraphNode(counter);
-                    
-                            //define node.graphNode
-			    var eqIri = g.nodess[n].eqIri.concat(g.nodess[tmp[0]].eqIri).filter(etyBase.helpers.onlyUnique);
-			   
-			    eqIri = eqIri.reduce(function(eq, element) {
-				eq = eq.concat(g.nodess[element].eqIri).filter(etyBase.helpers.onlyUnique)
-				return eq;
-			    }, []);
-			    var graphNode = eqIri.reduce(function(gn, element) {
-				if (undefined === g.nodess[element].graphNode) {
-				    return gn;
-				} else {
-				    gn.push(g.nodess[element].graphNode);
-				    return gn;
-				}
-                            }, []).filter(etyBase.helpers.onlyUnique).sort();
-			    if (graphNode.length === 0) {
-				graphNode = counter;
-				counter ++;
-			    } else {
-				graphNode = graphNode[0];
-			    } 
-				
-			    eqIri.forEach(function(element) {
-				g.nodess[element].eqIri = eqIri;
-				g.nodess[element].graphNode = graphNode;
-			    });			
-                
-                            counter++;
-			}
+                return g;
+            } else {
+                console.log("allArray");
+                console.log(allArray);
+                //CONSTRUCTING NODES
+                allArray.forEach(function(element) {
+                    //save all nodes        
+                    //define isAncestor
+                    if (undefined !== element.s && undefined === g.nodess[element.s.value]) {
+                        var label = (undefined === element.sLabel) ? undefined : element.sLabel.value;
+                        g.nodess[element.s.value] = new etyBase.LOAD.classes.Node(element.s.value, label);
                     }
-		}
-		
-		for (var n in g.nodess) {
+                    if (undefined !== element.rel) {
+                        if (undefined === g.nodess[element.rel.value]) {
+                            var label = (undefined === element.relLabel) ? undefined : element.relLabel.value;
+                            g.nodess[element.rel.value] = new etyBase.LOAD.classes.Node(element.rel.value, label);
+                        }
+                        if (ancestors.indexOf(element.rel.value) > -1) {
+                            g.nodess[element.rel.value].isAncestor = true;
+                        }
+                    }
+                    if (undefined !== element.rel && undefined !== element.eq) {
+                        if (undefined === g.nodess[element.eq.value]) {
+                            var label = (undefined === element.eqLabel) ? undefined : element.eqLabel.value;
+                            g.nodess[element.eq.value] = new etyBase.LOAD.classes.Node(element.eq.value, label);
+                        }
+                        //push to eqIri
+                        if (element.rel.value !== element.eq.value) {
+                            if (g.nodess[element.rel.value].eqIri.indexOf(element.eq.value) === -1) {
+                                g.nodess[element.rel.value].eqIri.push(element.eq.value);
+                            }
+                            if (g.nodess[element.eq.value].eqIri.indexOf(element.rel.value) === -1) {
+                                g.nodess[element.eq.value].eqIri.push(element.rel.value);
+                            }
+                        }
+                    }
+                });
+
+                //CONSTRUCTING GRAPHNODES
+                //a graphNode is some kind of super node that merges Nodes that are etymologically equivalent
+                //or that refer to the same word - also called here identical Nodes 
+                //(e.g.: if only ee_word and ee_n_word with n an integer belong to
+                //the set of ancestors and descendants           
+                //then merge them into one graphNode) 
+                //the final graph will use these super nodes (graphNodes)  
+                g.graphNodes = {};
+                var counter = 0; //counts how many graphNodes have been created so far
+                for (var n in g.nodess) {
+                    if (g.nodess[n].ety === 0) {
+                        var iso = g.nodess[n].iso;
+                        var label = g.nodess[n].label;
+                        var tmp = [];
+                        for (var m in g.nodess) {
+                            if (undefined !== g.nodess[m]) {
+                                if (g.nodess[m].iso === iso && g.nodess[m].label === label) {
+                                    if (g.nodess[m].ety > 0) {
+                                        tmp.push(m);
+                                    }
+                                }
+                            }
+                        }
+                        tmp = tmp.filter(etyBase.helpers.onlyUnique);
+                        //if only ee_word and ee_n_word with n an integer belong to
+                        //the set of ancestors and descendants
+                        //then merge them in one graphNode
+                        if (tmp.length === 1) {
+                            //        var gg = new etyBase.LOAD.classes.GraphNode(counter);
+
+                            //define node.graphNode
+                            var eqIri = g.nodess[n].eqIri.concat(g.nodess[tmp[0]].eqIri).filter(etyBase.helpers.onlyUnique);
+
+                            eqIri = eqIri.reduce(function(eq, element) {
+                                eq = eq.concat(g.nodess[element].eqIri).filter(etyBase.helpers.onlyUnique);
+                                return eq;
+                            }, []);
+                            var graphNode = eqIri.reduce(function(gn, element) {
+                                if (undefined === g.nodess[element].graphNode) {
+                                    return gn;
+                                } else {
+                                    gn.push(g.nodess[element].graphNode);
+                                    return gn;
+                                }
+                            }, []).filter(etyBase.helpers.onlyUnique).sort();
+                            if (graphNode.length === 0) {
+                                graphNode = counter;
+                                counter++;
+                            } else {
+                                graphNode = graphNode[0];
+                            }
+
+                            eqIri.forEach(function(element) {
+                                g.nodess[element].eqIri = eqIri;
+                                g.nodess[element].graphNode = graphNode;
+                            });
+
+                            counter++;
+                        }
+                    }
+                }
+
+                for (var n in g.nodess) {
                     if (undefined === g.nodess[n].graphNode) {
-			var eqIri = g.nodess[n].eqIri;
-			eqIri = eqIri.reduce(function(eq, element) {
-			    eq = eq.concat(g.nodess[element].eqIri).filter(etyBase.helpers.onlyUnique);
-			    return eq;
-			}, []);   
-			var graphNode = eqIri.reduce(function(gn, element) {
+                        var eqIri = g.nodess[n].eqIri;
+                        eqIri = eqIri.reduce(function(eq, element) {
+                            eq = eq.concat(g.nodess[element].eqIri).filter(etyBase.helpers.onlyUnique);
+                            return eq;
+                        }, []);
+                        var graphNode = eqIri.reduce(function(gn, element) {
                             if (undefined === g.nodess[element].graphNode) {
                                 return gn;
                             } else {
@@ -394,68 +399,77 @@ var GRAPH = (function(module) {
                         }, []).filter(etyBase.helpers.onlyUnique).sort();
                         if (graphNode.length === 0) {
                             graphNode = counter;
-                            counter ++;
+                            counter++;
                         } else {
                             graphNode = graphNode[0];
                         }
-			
+
                         eqIri.forEach(function(element) {
                             g.nodess[element].eqIri = eqIri;
                             g.nodess[element].graphNode = graphNode;
                         });
-			
+
                         counter++;
-		    }
-		}
-		
-		var graphNodes = [];
-		for (var n in g.nodess) {
-		    var gn = g.nodess[n].graphNode; 
-		    if (graphNodes.indexOf(gn) === -1) {
-			var gg = new etyBase.LOAD.classes.GraphNode(gn);
-			gg.counter = gn;
-			gg.iri = g.nodess[n].eqIri;
-			gg.iso = g.nodess[n].iso;
-			gg.label = gg.iri.map(function(i) { return g.nodess[i].label; }).filter(etyBase.helpers.onlyUnique).join(",");
-			gg.lang = g.nodess[n].lang;
-			g.setNode(gn, gg);
+                    }
+                }
 
-			graphNodes.push(gg.counter);  
-		    }
-		}
+                var graphNodes = [];
+                for (var n in g.nodess) {
+                    var gn = g.nodess[n].graphNode;
+                    if (graphNodes.indexOf(gn) === -1) {
+                        var gg = new etyBase.LOAD.classes.GraphNode(gn);
+                        gg.counter = gn;
+                        gg.iri = g.nodess[n].eqIri;
+                        gg.iso = g.nodess[n].iso;
+                        gg.label = gg.iri.map(function(i) { return g.nodess[i].label; }).filter(etyBase.helpers.onlyUnique).join(",");
+                        gg.lang = g.nodess[n].lang;
+                        g.setNode(gn, gg);
 
-		//CONSTRUCTING LINKS
-		allArray.forEach(function(element) {
+                        graphNodes.push(gg.counter);
+                    }
+                }
+
+                //CONSTRUCTING LINKS
+                allArray.forEach(function(element) {
                     if (undefined !== element.rel && undefined !== element.s) {
-			var source = g.nodess[element.rel.value].graphNode,
-                        target = g.nodess[element.s.value].graphNode;
-			if (source !== target) {
+                        var source = g.nodess[element.rel.value].graphNode,
+                            target = g.nodess[element.s.value].graphNode;
+                        if (source !== target) {
                             g.setEdge(source, target, { label: "", lineInterpolate: "basis" });
-			}
-                    }		    
-		});
+                        }
+                    }
+                });
 
-		//todo: add links between ancestors
-		
-		if (etyBase.config.debug) {
-		    console.log("g.nodess");
-		    console.log(g.nodess) ;  
-		    console.log("g");
-		    console.log(g);
-		}
-		console.log("g.nodess");
-                console.log(g.nodess) ;
+                //todo: add links between ancestors
+
+                if (etyBase.config.debug) {
+                    console.log("g.nodess");
+                    console.log(g.nodess);
+                    console.log("g");
+                    console.log(g);
+                }
+                console.log("g.nodess");
+                console.log(g.nodess);
                 console.log("g");
                 console.log(g);
-		
-		$('#message')
-                    .css('display', 'none');
-		
-		return g;
-            }
-	};
 
-        var renderGraph = function(g) {
+                $('#message')
+                    .css('display', 'none');
+
+                return g;
+            }
+        };
+
+        var setGraph = function(g) {
+        	etyBase.tree.graph = g;
+        };
+
+        var renderGraph = function() {
+        	if (!etyBase.tree.graph) {
+        		console.error('Empty Graph');
+        		return false;
+        	}
+        	var g = etyBase.tree.graph;
             var svg = d3.select("#tree-container").append("svg")
                 .attr("id", "tree-overlay")
                 .attr("width", window.innerWidth)
@@ -482,26 +496,26 @@ var GRAPH = (function(module) {
                 .scale(initialScale)
                 .event(svg);
 
-	    //append language tag to nodes            
+            //append language tag to nodes            
             inner.selectAll("g.node")
                 .append("text")
                 .style("width", "auto")
                 .style("height", "auto")
                 .style("display", "inline")
-		.attr("class", "isoText")
+                .attr("class", "isoText")
                 .attr("x", "1em")
                 .attr("y", "3em")
-		.html(function(d) {
+                .html(function(d) {
                     return g.node(d).iso;
                 });
-	    
+
             //show tooltip on click on language tag   
             inner.selectAll("g.node")
                 .append("rect")
-		.attr("x", "0.8em")
+                .attr("x", "0.8em")
                 .attr("y", "2.2em")
                 .attr("x", "0.8em")
-		.attr("width", function(d) {
+                .attr("width", function(d) {
                     return g.node(d).iso.length / 1.7 + "em";
                 })
                 .attr("height", "1em")
@@ -529,19 +543,19 @@ var GRAPH = (function(module) {
                         g.nodess[iri].logTooltip();
                     } else {
                         iri.reduce(function(obj, i) {
-			    var label = g.nodess[i].label;
-			    if (obj.labels.indexOf(label) === -1) {
-				obj.labels.push(label);
-				obj.iris.push(i);
-				return obj;
-			    } else {
-				return obj;
-			    }
+                            var label = g.nodess[i].label;
+                            if (obj.labels.indexOf(label) === -1) {
+                                obj.labels.push(label);
+                                obj.iris.push(i);
+                                return obj;
+                            } else {
+                                return obj;
+                            }
                         }, { labels: [], iris: [] }).iris.forEach(function(i) { g.nodess[i].logTooltip(); });
                     }
                     d3.event.stopPropagation();
                 });
-	    
+
             //svg.attr("height", g.graph().height * initialScale + 40);}}
             return inner;
         };
@@ -549,7 +563,7 @@ var GRAPH = (function(module) {
         var init = function() {
 
             $('#helpPopup')
-		.html(etyBase.LOAD.HELP.intro);
+                .html(etyBase.LOAD.HELP.intro);
 
             var div = d3.select("body").append("div")
                 .attr("data-role", "popup")
@@ -575,7 +589,7 @@ var GRAPH = (function(module) {
                     if (lemma) {
                         var width = window.innerWidth,
                             height = $(document).height() - $('#header').height();
-			constructDisambiguationGraph(lemma);
+                        constructDisambiguationGraph(lemma);
                     }
                 }
             });
@@ -584,7 +598,7 @@ var GRAPH = (function(module) {
         };
 
         this.init = init;
-        
+
         etyBase[moduleName] = this;
     };
 

--- a/resources/js/load.js
+++ b/resources/js/load.js
@@ -27,7 +27,7 @@ var LOAD = (function(module) {
             serverError: "Sorry, the server cannot extract etymological relationships correctly for this word.",
             noEtymology: "Sorry, it seems like no etymology is available in the English Wiktionary for this word.",
             loadingMore: "Loading, please wait...",
-	    disambiguation: "There are multiple words in the database. <br>Which word are you interested in?"
+            disambiguation: "There are multiple words in the database. <br>Which word are you interested in?"
         };
 
         class GraphNode {
@@ -48,7 +48,7 @@ var LOAD = (function(module) {
                 var tmp = this.parseIri(i);
                 this.iso = tmp.iso;
                 this.label = (undefined === label) ? tmp.label : label;
-		this.label = this.label.replace(/^_/, '*').replace("__", "'").replace("%C2%B7", "·");
+                this.label = this.label.replace(/^_/, '*').replace("__", "'").replace("%C2%B7", "·");
                 //ety is an integer                              
                 //and represents the etymology number encoded in the iri;
                 this.ety = tmp.ety;
@@ -57,7 +57,7 @@ var LOAD = (function(module) {
                 this.graphNode = undefined;
                 //eqIri is an array of iri-s of Node-s that are equivalent to the Node 
                 this.eqIri = [];
-		this.eqIri.push(i);
+                this.eqIri.push(i);
                 this.isAncestor = false;
 
                 this.shape = "rect";
@@ -66,8 +66,8 @@ var LOAD = (function(module) {
             }
 
             logTooltip() {
-		console.log("this.iri");
-		console.log(this.iri);
+                console.log("this.iri");
+                console.log(this.iri);
                 var query = etyBase.DB.lemmaQuery(this.iri);
                 var url = etyBase.config.urls.ENDPOINT + "?query=" + encodeURIComponent(query);
 
@@ -84,8 +84,8 @@ var LOAD = (function(module) {
                         if (null !== response) {
                             //print definition  
                             var dataJson = JSON.parse(response).results.bindings;
-			    console.log("dataJson")
-			    console.log(dataJson)
+                            console.log("dataJson")
+                            console.log(dataJson)
                             text += dataJson.reduce(
                                 function(s, element) {
                                     return s += that.logDefinition(element.pos, element.gloss);


### PR DESCRIPTION
I wrote a function to set a tree property `etyBase.tree.data` as a "complete" version of the allArray so that we could reference the property for graph drawing and graph refreshes without having to poll or edit the queries again when there is a change. This is the first step in setting the graph up to be collapsible, per issue #22 -- If we edit the data property and call `parseEtymologyNodes`, a different (collapsed?) graph could be drawn.