### PR TITLE
Defer etytree file until js is completely loaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/hopscotch/0.2.7/js/hopscotch.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.4.1/Rx.min.js"></script>
 <script src="./vendors/dagre-d3/dagre-d3.js"></script>
-<script async src="./resources/js/liveTour.js"></script>
-<script async src="./resources/js/sparql.js"></script>   
-<script async src="./resources/js/load.js"></script>
-<script async src="./resources/js/dagre.js"></script>
-<script async src="./resources/js/etytree.js"></script>  
 <body> 
   <div data-role="header" id="header">
     <table style="empty-cells:hide; margin-left:auto; margin-right:auto;">
@@ -97,5 +92,10 @@
         </div>
       </div>
     </div>
+    <script src="./resources/js/liveTour.js"></script>
+    <script src="./resources/js/sparql.js"></script>   
+    <script src="./resources/js/load.js"></script>
+    <script src="./resources/js/dagre.js"></script>
+    <script src="./resources/js/etytree.js" defer></script>  
 </body>
 </html>

--- a/resources/js/etytree.js
+++ b/resources/js/etytree.js
@@ -55,7 +55,7 @@ var EtyTree = {
 
 var ety;
 
-jQuery('document').ready(function($) {
+jQuery(window).load(function($) {
     ety = EtyTree.create();
     ety.init();
 });


### PR DESCRIPTION
issue #33 seems to have been from the way that I was loading the js files asynchronously. I removed the async tags, added a defer tag to etytree.js, set init to run on window load, and moved the  script tags to the footer for efficient loading. The glitch seems to have resolved.